### PR TITLE
docs: align README/AGENTS with extension LLM UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,11 +34,11 @@ This repository maintains generated docs and source-of-truth artifacts for AI to
 
 ## Current Product Notes
 - The repository's primary deliverable is the Python CLI package `repo-wiki`, a local-first repository Wiki generator.
-- The VS Code/Cursor extension is `extensions/repo-wiki-browser`. Current packaged versions browse READY releases and run a configurable terminal command; they do **not** yet provide visual LLM provider/model/base URL/API Key configuration.
-- Because Wiki generation requires LLM access, new target projects must configure the CLI manually before using the extension:
-  1. Create non-secret `repo-wiki.yaml` / `.repo-wiki.yaml`, or set `LLM_*` environment variables.
-  2. Keep real API Keys out of settings, YAML, command strings, logs, docs, and committed files.
-  3. Prefer temporary integrated-terminal environment variables until SecretStorage support is implemented; shell profile and untracked `.env` are local-disk persistence options only when the user accepts that risk.
+- The VS Code/Cursor extension is `extensions/repo-wiki-browser`. It browses READY releases, runs a configurable terminal command, and **does** provide visual LLM provider/model/base URL/`api_key_env` configuration plus SecretStorage for the API Key. Only the Python CLI calls the LLM.
+- Because Wiki generation requires LLM access, configure the CLI before generate:
+  1. Preferred: extension commands Configure LLM Settings / Set LLM API Key / Test LLM Configuration.
+  2. Fallback: non-secret `repo-wiki.yaml` / `.repo-wiki.yaml`, or `LLM_*` environment variables.
+  3. Keep real API Keys out of settings, YAML, command strings, logs, docs, and committed files. Store keys in SecretStorage or a temporary env var.
   4. Validate with `repo-wiki config --ci`.
   5. Generate, verify, and publish with `generate --profile qoder-like`, `verify --profile qoder-like --ci`, and `release-publish`.
 - The VS Code extension reads the stable READY release at `.repo-agent-eval/repowiki/zh/manifest.json`; if a run is generated but not published, the extension may show no browsable Wiki.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ repo-wiki --help
 
 ### 2. 在目标项目配置 LLM
 
-当前 VS Code/Cursor 插件还不支持可视化配置 LLM。生成 Wiki 前，需要先在目标项目中人工配置 CLI 的 LLM 接入。
+推荐用 VS Code/Cursor 插件侧栏配置：活动栏 **Repo Wiki** → **Configure LLM Settings** / **Set LLM API Key** / **Test LLM Configuration**。Key 进入 VS Code SecretStorage，不写入 YAML 或普通 settings。真正调用 LLM 的仍是 Python CLI。
+
+YAML + 环境变量仍可用（CI、纯终端、或旧 VSIX）。从本仓重新 `vsce package` 后才有上述 UI。
 
 在目标项目根目录创建 `repo-wiki.yaml`，只写非敏感配置：
 
@@ -57,7 +59,7 @@ llm:
 export REPO_WIKI_LLM_API_KEY="<your-api-key>"
 ```
 
-不要把真实 API Key 写入 `repo-wiki.yaml`、VS Code settings、命令字符串、日志、文档或已提交文件。当前插件实现 SecretStorage 前，推荐优先使用临时终端环境变量；shell profile 或未提交 `.env` 属于本机落盘方案，仅在你接受该风险时使用。
+不要把真实 API Key 写入 `repo-wiki.yaml`、VS Code settings、命令字符串、日志、文档或已提交文件。插件里用 **Set LLM API Key** 写入 SecretStorage；终端场景用临时环境变量。shell profile 或未提交 `.env` 仅在你接受本机落盘风险时使用。
 
 也可以不写 YAML，直接使用环境变量：
 
@@ -152,15 +154,17 @@ repo-wiki release-publish --output .repo-agent-eval
 
 - 浏览 `.repo-agent-eval/repowiki/zh/manifest.json` 中 READY release 的 `navigation_tree`；
 - 打开生成的 Markdown 预览；
-- 触发 `Repo Wiki: Update Wiki`，本质是向 VS Code 集成终端发送 `repoWikiBrowser.generateCommand`；
+- 触发 `Repo Wiki: Update Wiki`，向集成终端发送 `repoWikiBrowser.generateCommand`，并按 source 策略注入非空 `LLM_*`；
+- 可视化配置 provider / model / base URL / `api_key_env`（Configure LLM Settings）；
+- 用 SecretStorage 保存/清除 API Key（Set / Clear LLM API Key）；
+- 运行 `Repo Wiki: Test LLM Configuration`（`repo-wiki config --ci`，输出脱敏）；
 - 展示 `repo-wiki.yaml` / `.repo-wiki.yaml` 中的 LLM 摘要。
 
 当前插件限制：
 
-- 尚不支持可视化配置 LLM provider / model / base URL / API Key；
-- 尚不支持 SecretStorage 保存 API Key；
-- 尚不自动注入 `LLM_PROVIDER`、`LLM_MODEL`、`LLM_BASE_URL`、`LLM_API_KEY_ENV`；
-- 使用插件前仍需按上文或 `docs/operations/vscode-extension-manual-llm-configuration.md` 手动配置 CLI 环境。
+- 扩展不内嵌 Python，也不直接调用 LLM；
+- 未执行 `release-publish` 时可能看不到可浏览 Wiki；
+- 旧 VSIX 可能没有 LLM UI，需从本仓按下面步骤重新打包。
 
 重新打包插件：
 

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -40,6 +40,6 @@ repo-wiki release-publish --output .repo-agent-eval
 ## 下一步
 
 - 架构：`docs/01-architecture.md`
-- 配置：`docs/configuration.md`
+- 配置：`docs/configuration.md`；插件可配 LLM（Key 进 SecretStorage），见扩展 README 与 `docs/operations/vscode-extension-manual-llm-configuration.md`
 - 安装与插件：`docs/operations/installation-and-vscode-extension.md`
 - Agent 入口：仓库根 `AGENTS.md`

--- a/docs/operations/vscode-extension-manual-llm-configuration.md
+++ b/docs/operations/vscode-extension-manual-llm-configuration.md
@@ -1,6 +1,6 @@
-# VS Code 插件当前版本的 LLM 人工配置指南
+# VS Code 插件 LLM 配置：UI 主路径与终端后备
 
-**状态：** 当前可用路径 / 插件可视化配置落地前的必备文档
+**状态：** 与本仓扩展源码对齐。插件 UI + SecretStorage 为推荐路径；本文保留 YAML/env 供 CI、纯终端、旧 VSIX。
 **日期：** 2026-07-08
 **适用对象：** 使用 `Repo Wiki Browser` VS Code/Cursor 插件触发 `repo-wiki` CLI 生成 Wiki 的用户
 **完整 CLI 配置参考：** `docs/configuration.md`
@@ -10,19 +10,9 @@
 
 ## 1. 先说结论
 
-当前 `Repo Wiki Browser` 插件 **还不支持在插件 UI 中配置 LLM**。当前已安装/打包的插件只支持：
-
-- 浏览 READY Wiki release；
-- 展示 `repo-wiki.yaml` / `.repo-wiki.yaml` 中的 LLM 摘要；
-- 执行 `repoWikiBrowser.generateCommand` 指定的终端命令；
-- 默认命令为 `uv run repo-wiki generate --profile qoder-like`。
-
-因此，在插件可视化配置实现前，必须通过 **CLI 运行环境** 人工配置 LLM。推荐方式是：
-
-1. 在目标仓库写入非敏感 `repo-wiki.yaml`；
-2. 通过 shell 环境变量或本地未提交 `.env` 设置真实 API Key；
-3. 先运行 `uv run repo-wiki config --ci` 验证配置；
-4. 再用插件 `Repo Wiki: Update Wiki` 或终端命令生成 Wiki。
+本仓 `extensions/repo-wiki-browser` **已经支持**在插件 UI 中配置 LLM（Configure / Set Key / Clear / Test）。Key 进入 SecretStorage。真正调用 LLM 的仍是 `repo-wiki` CLI。
+UI 逐步说明见 `extensions/repo-wiki-browser/README.md` 的 LLM configuration 一节。
+在没有插件、CI、或只想用终端时，继续用下面的 YAML + 环境变量。旧 VSIX 若看不到这些命令，从本仓重新 `vsce package`。
 
 ---
 
@@ -30,17 +20,19 @@
 
 | 能力 | 当前状态 | 说明 |
 | --- | --- | --- |
-| 插件 UI 配置 provider | 未支持 | 后续见 `docs/specs/vscode-llm-configuration-spec.md`。 |
-| 插件 UI 配置 model | 未支持 | 当前只能通过 YAML / env / CLI 运行环境配置。 |
-| 插件 UI 配置 base_url | 未支持 | 当前只能通过 YAML / env / CLI 运行环境配置。 |
-| 插件 SecretStorage 保存 API Key | 未支持 | 当前不要把 key 写入 VS Code settings。 |
-| 插件自动注入 `LLM_*` env | 未支持 | 当前 `Update Wiki` 只是向集成终端发送命令。 |
+| 插件 UI 配置 provider | 已支持（源码） | Configure LLM Settings。 |
+| 插件 UI 配置 model | 已支持（源码） | Configure LLM Settings。 |
+| 插件 UI 配置 base_url | 已支持（源码） | Configure LLM Settings。 |
+| 插件 SecretStorage 保存 API Key | 已支持（源码） | Set / Clear LLM API Key。不要把 key 写入 VS Code settings。 |
+| 插件自动注入 `LLM_*` env | 已支持（源码） | Update Wiki 按 source 策略注入非空 `LLM_*`。 |
 | 展示 YAML 中 LLM 摘要 | 已支持 | 只展示 provider/model 等摘要，不管理 key。 |
 | 自定义生成命令 | 已支持 | 设置项：`repoWikiBrowser.generateCommand`。 |
 
 ---
 
 ## 3. 推荐安全配置方式
+
+无插件 UI 时用本节。有插件时优先 SecretStorage，不要把 key 写入 YAML。
 
 ### 3.1 在目标仓库写入非敏感 YAML
 

--- a/tests/test_docs_llm_ui_alignment.py
+++ b/tests/test_docs_llm_ui_alignment.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+README = (ROOT / "README.md").read_text(encoding="utf-8")
+AGENTS = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+
+STALE_PHRASES = (
+    "还不支持可视化配置 LLM",
+    "尚不支持可视化配置 LLM",
+    "尚不支持 SecretStorage",
+    "do **not** yet provide visual LLM",
+    "until SecretStorage support is implemented",
+)
+
+
+def test_root_docs_do_not_claim_llm_ui_is_missing() -> None:
+    blob = README + "\n" + AGENTS
+    hits = [phrase for phrase in STALE_PHRASES if phrase in blob]
+    assert hits == [], f"stale LLM-UI denial still in README/AGENTS: {hits}"
+
+
+def test_readme_documents_secretstorage_and_config_ci() -> None:
+    assert "SecretStorage" in README
+    assert "repo-wiki config --ci" in README
+    assert ("Configure LLM" in README) or ("配置 LLM" in README)
+
+
+def test_agents_says_extension_has_visual_llm() -> None:
+    assert "SecretStorage" in AGENTS
+    lowered = AGENTS.lower()
+    assert "visual" in lowered or "可视化" in AGENTS


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Docs now follow the extension source: the VS Code/Cursor plugin **does** provide visual LLM provider/model/base URL/`api_key_env` configuration and SecretStorage for the API Key.

The Python CLI remains the only LLM caller. YAML + `LLM_*` environment variables stay as fallbacks for CI, pure terminal, and old VSIX builds.

This PR is documentation + guard tests only. It does **not** change `extensions/repo-wiki-browser/src/**`, and it is **not** subprojects 3/4.

## Type of Change
- [x] Documentation update (typos, docs, etc.)
- [x] Tests (adding or updating tests)

## Related Issue

LLM UI docs-alignment plan (Tasks 1–6) on branch `docs/llm-ui-alignment`.

## Testing Performed
- [x] Ran tests locally: `pytest tests/test_docs_llm_ui_alignment.py tests/test_docs_naming_alignment.py tests/test_docs_examples.py tests/test_secret_sentinel_artifacts.py -v` — 25 passed
- [ ] Ran linting: `ruff check .`

Stale-denial `rg` on `README.md` and `AGENTS.md` is empty. `git diff origin/main -- extensions/repo-wiki-browser/src` is empty.

## Checklist
- [x] My code follows the project's code style
- [x] I have performed self-review
- [x] I have commented complex code areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75559bac-8fae-4439-ba19-cb38cd8ff923?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75559bac-8fae-4439-ba19-cb38cd8ff923&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

