### PR TITLE
fix: default LLM provider openai and optional chromadb extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## 核心能力
 
 - **Qoder-like 输出** — 提供隔离生成、发布清单和可配置的严格质量门禁
-- **Local-first** — 无需外部数据库，SQLite + ChromaDB 嵌入式运行
+- **Local-first** — 无需外部数据库；SQLite+FTS 必有。Chroma 可选（`pip install 'repo-wiki[vector]'`），未安装时语义索引降级为本地 `vectors.json`
 - **隔离输出** — `--profile qoder-like` 输出到 `.repo-agent-eval/`，不污染目标仓库
 - **增量更新** — 基于 git diff 实现页面级失效和选择性重生成
 - **Strict Verify** — 13 项质量门禁（prose density、citations、Mermaid、stale commit 等）
@@ -52,6 +52,8 @@ llm:
   base_url: https://api.example.com/v1
   api_key_env: REPO_WIKI_LLM_API_KEY
 ```
+
+无 YAML 时默认 `provider=openai`、`model=gpt-4o-mini`。要用 Anthropic 请在 YAML 里显式写 `provider: anthropic`。
 
 然后在当前 VS Code 集成终端或 shell 中设置真实 API Key：
 
@@ -216,7 +218,7 @@ code --install-extension repo-wiki-browser-0.1.0.vsix --force
 
 - **Python 3.11+** with `uv` package manager
 - **SQLite/FTS5** — 本地状态和全文检索
-- **ChromaDB** — 语义向量存储
+- **ChromaDB** — 可选语义向量存储（`repo-wiki[vector]`）；未安装时 JSON fallback
 - **LLM** — OpenAI-compatible / Minimax
 - **VS Code/Cursor Extension** — TypeScript sidebar for browsing READY Wiki releases
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
   "ruff>=0.1",
   "mypy>=1.8",
 ]
+vector = ["chromadb>=0.5.0"]
 
 [project.scripts]
 repo-wiki = "repo_wiki.cli:app"

--- a/repo_wiki/core/config.py
+++ b/repo_wiki/core/config.py
@@ -36,7 +36,7 @@ class IndexConfig(BaseModel):
 class LlmConfig(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
-    provider: str = "anthropic"
+    provider: str = "openai"
     model: str | None = None
     base_url: str | None = None
     api_key_env: str | None = None

--- a/repo_wiki/indexer/vector_store.py
+++ b/repo_wiki/indexer/vector_store.py
@@ -6,7 +6,10 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
+from repo_wiki.core.logging import warn
 from repo_wiki.generator.io import ensure_dir
+
+_CHROMA_FALLBACK_LOGGED = False
 
 
 @dataclass
@@ -42,7 +45,14 @@ class ChromaVectorStore:
 
             self._chroma = chromadb.PersistentClient(path=str(root_dir))
             self._collection = self._chroma.get_or_create_collection("repo_wiki_chunks")
-        except Exception:
+        except Exception as exc:
+            global _CHROMA_FALLBACK_LOGGED
+            if isinstance(exc, ImportError) and not _CHROMA_FALLBACK_LOGGED:
+                warn(
+                    "ChromaDB not installed; using vectors.json fallback. "
+                    "Install with: pip install 'repo-wiki[vector]'"
+                )
+                _CHROMA_FALLBACK_LOGGED = True
             self._chroma = None
             self._collection = None
 

--- a/repo_wiki/indexer/vector_store.py
+++ b/repo_wiki/indexer/vector_store.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import json
 import math
+import sys
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
-from repo_wiki.core.logging import warn
 from repo_wiki.generator.io import ensure_dir
 
 _CHROMA_FALLBACK_LOGGED = False
@@ -48,9 +48,10 @@ class ChromaVectorStore:
         except Exception as exc:
             global _CHROMA_FALLBACK_LOGGED
             if isinstance(exc, ImportError) and not _CHROMA_FALLBACK_LOGGED:
-                warn(
-                    "ChromaDB not installed; using vectors.json fallback. "
-                    "Install with: pip install 'repo-wiki[vector]'"
+                print(
+                    "WARN ChromaDB not installed; using vectors.json fallback. "
+                    "Install with: pip install 'repo-wiki[vector]'",
+                    file=sys.stderr,
                 )
                 _CHROMA_FALLBACK_LOGGED = True
             self._chroma = None

--- a/tests/test_llm_and_vector_defaults.py
+++ b/tests/test_llm_and_vector_defaults.py
@@ -31,4 +31,6 @@ def test_readme_does_not_claim_chroma_is_unconditional() -> None:
     text = (ROOT / "README.md").read_text(encoding="utf-8")
     assert "SQLite + ChromaDB 嵌入式运行" not in text
     assert "chromadb" in text.lower() or "Chroma" in text
-    assert "vector" in text.lower() or "fallback" in text.lower() or "降级" in text or "可选" in text
+    assert (
+        "vector" in text.lower() or "fallback" in text.lower() or "降级" in text or "可选" in text
+    )

--- a/tests/test_llm_and_vector_defaults.py
+++ b/tests/test_llm_and_vector_defaults.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from repo_wiki.core.config import LlmConfig
+from repo_wiki.llm.config import resolve_llm_config
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_llm_config_default_provider_is_openai() -> None:
+    assert LlmConfig().provider == "openai"
+
+
+def test_dumped_llm_config_resolves_to_openai_not_claude() -> None:
+    cfg, _warnings = resolve_llm_config(config=LlmConfig().model_dump())
+    assert cfg.provider == "openai"
+    assert cfg.model == "gpt-4o-mini"
+    assert not str(cfg.model).startswith("claude-")
+    assert cfg.api_key_env == "OPENAI_API_KEY"
+
+
+def test_pyproject_has_chromadb_vector_extra() -> None:
+    data = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    vector = data["project"]["optional-dependencies"]["vector"]
+    assert any(item.startswith("chromadb") for item in vector)
+
+
+def test_readme_does_not_claim_chroma_is_unconditional() -> None:
+    text = (ROOT / "README.md").read_text(encoding="utf-8")
+    assert "SQLite + ChromaDB 嵌入式运行" not in text
+    assert "chromadb" in text.lower() or "Chroma" in text
+    assert "vector" in text.lower() or "fallback" in text.lower() or "降级" in text or "可选" in text

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from repo_wiki.indexer import vector_store as vector_store_mod
+from repo_wiki.indexer.vector_store import ChromaVectorStore
+
+
+def test_chroma_fallback_notice_does_not_write_to_stdout(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(vector_store_mod, "_CHROMA_FALLBACK_LOGGED", False)
+    monkeypatch.setitem(sys.modules, "chromadb", None)
+
+    ChromaVectorStore(tmp_path)
+
+    captured = capsys.readouterr()
+    assert "ChromaDB" not in captured.out
+    assert "ChromaDB" in captured.err


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`LlmConfig.provider` was overriding `resolve_llm_config` openai defaults via `model_dump()`; chromadb is optional extra not hard dep; JSON fallback documented + logged; staged Claude fields kept for explicit anthropic. Not subproject 4 (init SOFT).

- Default `LlmConfig.provider` is now `openai`, so dumped config no longer forces Anthropic/Claude when resolving LLM settings.
- `LlmConfig.model_init` / `model_update` / `model_verify` Claude fields are unchanged for explicit Anthropic use.
- `chromadb` is an optional extra (`pip install 'repo-wiki[vector]'`), not a hard dependency. Lower bound is `chromadb>=0.5.0` (compatible with Python 3.11; no raise needed).
- Missing Chroma logs once and keeps the existing `vectors.json` fallback.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update (typos, docs, etc.)
- [x] Tests (adding or updating tests)

## Testing Performed
- [x] Ran tests locally: `pytest`
  - RED: `tests/test_llm_and_vector_defaults.py` — 4 failed on current main
  - GREEN: `pytest tests/test_llm_and_vector_defaults.py tests/test_llm_config.py tests/test_docs_naming_alignment.py tests/test_docs_llm_ui_alignment.py -v` — 33 passed
- [x] `rg -n 'SQLite \+ ChromaDB 嵌入式运行' README.md` empty
- [x] `git diff origin/main -- extensions/repo-wiki-browser/src` empty

## Checklist
- [x] My code follows the project's code style
- [x] I have performed self-review
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] Did not edit `extensions/repo-wiki-browser/src/**`
- [x] Did not change `.repo-agent-eval` paths
- [x] Did not make chromadb a hard dependency
- [x] Did not delete `LlmConfig.model_init` / `model_update` / `model_verify`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a9772df-0e33-49be-8d2f-b617a4536460?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a9772df-0e33-49be-8d2f-b617a4536460&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

