### PR TITLE
fix: stop inventing HTTP API contracts when api-index is empty

### DIFF
--- a/docs/04-api-contracts.md
+++ b/docs/04-api-contracts.md
@@ -1,37 +1,18 @@
-# API Contracts - repo-agent
+# API Contracts - repo-wiki-agent
+
+<cite>repo_wiki/cli.py:1</cite>
 
 本页面按服务族（Service Family）和主题域（Domain Theme）聚合 API 端点，展示认证模式、调用约定和关键入口点。详细端点列表请参考 `ai/source-of-truth/api-index.yaml`。
 
 ## 服务/API 分组
 
-| 服务族/域 | 端点数 | 认证模式 | 暴露类型 |
-|-----------|--------|----------|---------|
-| python-backend/core-platform | 10 | bearer/none | internal/public/webhook |
+本仓库未扫描到 HTTP API 端点。产品接口是 `repo-wiki` CLI 命令面，见 `ai/source-of-truth/task-catalog.yaml` 与 README。
 
 ---
 
 ## 分组详情
 
-### python-backend/core-platform
-
-**主题域**: core-platform | **服务族**: python-backend | **运行时角色**: api-server
-**端点数量**: 10
-
-**python-backend/core-platform** 接口调用约定：
-
-- HTTP 方法: GET, POST
-- 认证: 需要 Bearer Token
-- 请求体: JSON 格式
-- 响应格式: JSON
-- 关键入口: `/path`, `/health`, `/items`
-
-**关键入口点**：
-- **POST** `/webhook/github` (POST 操作 + 根级路径)
-- **GET** `/health` (公开接口 + 根级路径)
-- **GET** `/ready` (公开接口 + 根级路径)
-- **GET** `/status` (公开接口 + 根级路径)
-- **POST** `/items` (POST 操作 + 根级路径)
-
+本仓库未扫描到 HTTP API 端点。产品接口是 `repo-wiki` CLI 命令面，见 `ai/source-of-truth/task-catalog.yaml` 与 README。
 
 ---
 
@@ -39,56 +20,23 @@
 
 ### 认证方式
 
-系统 API 认证约定：
-- **repo_wiki**: bearer
-- **tests**: none
+本仓库未扫描到 HTTP API 端点。产品接口是 `repo-wiki` CLI 命令面，见 `ai/source-of-truth/task-catalog.yaml` 与 README。
+认证约定：不适用（无 HTTP 端点）。
 
 ### 错误与状态码
 
-API 错误与状态码约定：
-
-| 状态码 | 含义 | 使用场景 |
-|--------|------|---------|
-| 200 | OK | 成功响应 |
-| 400 | Bad Request | 请求参数错误 |
-| 401 | Unauthorized | 未认证或认证失败 |
-| 403 | Forbidden | 无权限访问 |
-| 404 | Not Found | 资源不存在 |
-| 500 | Internal Server Error | 服务器内部错误 |
-
-**常见错误码**: 400, 401, 403, 404, 500
+本仓库未扫描到 HTTP API 端点。产品接口是 `repo-wiki` CLI 命令面，见 `ai/source-of-truth/task-catalog.yaml` 与 README。
+错误码约定：不适用（无 HTTP 端点）。
 
 ### 关键入口 API
 
-系统中的关键入口 API：
-
-- **POST** `/webhook/github` (tests.test_endpoint_inherits_module_service_family) - POST 操作 + 根级路径
-- **GET** `/health` (tests.test_endpoint_inherits_module_service_family) - 公开接口 + 根级路径
-- **GET** `/ready` (tests.test_endpoint_inherits_module_service_family) - 公开接口 + 根级路径
-- **GET** `/status` (tests.test_endpoint_inherits_module_service_family) - 公开接口 + 根级路径
-- **POST** `/items` (tests.test_endpoint_inherits_module_service_family) - POST 操作 + 根级路径
-- **POST** `/users` (tests.test_endpoint_inherits_module_service_family) - POST 操作 + 根级路径
-- **GET** `/path` (repo_wiki.__init__) - 需要认证 + 根级路径
-- **GET** `/items` (tests.test_endpoint_inherits_module_service_family) - 根级路径
-- **GET** `/users` (tests.test_endpoint_inherits_module_service_family) - 根级路径
-- **GET** `/users` (tests.test_scanner_and_source_of_truth_outputs) - 根级路径
+- 暂无关键入口 API 定义
 
 ---
 
 ## 完整端点索引
 
-| 方法 | 路径 | 模块 | 处理器 | 文档 |
-|------|------|------|--------|------|
-| GET | `/path` | repo_wiki | `__init__` | [模块文档](modules/repo_wiki.md) |
-| GET | `/health` | tests | `test_endpoint_inherits_module_service_family` | [测试模块](modules/tests.md) |
-| GET | `/items` | tests | `test_endpoint_inherits_module_service_family` | [测试模块](modules/tests.md) |
-| POST | `/items` | tests | `test_endpoint_inherits_module_service_family` | [测试模块](modules/tests.md) |
-| GET | `/ready` | tests | `test_endpoint_inherits_module_service_family` | [测试模块](modules/tests.md) |
-| GET | `/status` | tests | `test_endpoint_inherits_module_service_family` | [测试模块](modules/tests.md) |
-| GET | `/users` | tests | `test_endpoint_inherits_module_service_family` | [测试模块](modules/tests.md) |
-| GET | `/users` | tests | `test_scanner_and_source_of_truth_outputs` | [测试模块](modules/tests.md) |
-| POST | `/users` | tests | `test_endpoint_inherits_module_service_family` | [测试模块](modules/tests.md) |
-| POST | `/webhook/github` | tests | `test_endpoint_inherits_module_service_family` | [测试模块](modules/tests.md) |
+本仓库未扫描到 HTTP API 端点。产品接口是 `repo-wiki` CLI 命令面，见 `ai/source-of-truth/task-catalog.yaml` 与 README。
 
 ---
 

--- a/repo_wiki/generator/engine.py
+++ b/repo_wiki/generator/engine.py
@@ -604,6 +604,11 @@ class APIAggregator:
     Phase 10 - Task 10.2: True API aggregation and entry-point summarization
     """
 
+    NO_HTTP_API_MESSAGE = (
+        "本仓库未扫描到 HTTP API 端点。产品接口是 `repo-wiki` CLI 命令面，"
+        "见 `ai/source-of-truth/task-catalog.yaml` 与 README。"
+    )
+
     def __init__(
         self,
         endpoints: list[dict[str, Any]],
@@ -799,6 +804,8 @@ class APIAggregator:
 
     def summarize_auth_conventions(self) -> str:
         """Summarize authentication conventions across all endpoints."""
+        if not self.api_endpoints:
+            return self.NO_HTTP_API_MESSAGE + "\n认证约定：不适用（无 HTTP 端点）。"
         auth_by_module: dict[str, set[str]] = {}
         for ep in self.api_endpoints:
             if ep.module not in auth_by_module:
@@ -814,6 +821,8 @@ class APIAggregator:
 
     def summarize_error_conventions(self) -> str:
         """Summarize error and status code conventions."""
+        if not self.api_endpoints:
+            return self.NO_HTTP_API_MESSAGE + "\n错误码约定：不适用（无 HTTP 端点）。"
         # Group error codes by pattern
         common_codes: set[int] = set()
         for ep in self.api_endpoints:
@@ -880,6 +889,8 @@ class APIAggregator:
     def build_api_groups_table(self) -> str:
         """Build API groups overview table with service family and domain grouping."""
         groups = self.group_by_service_family()
+        if not groups:
+            return self.NO_HTTP_API_MESSAGE
 
         lines = [
             "| 服务族/域 | 端点数 | 认证模式 | 暴露类型 |",
@@ -905,6 +916,8 @@ class APIAggregator:
     def build_api_groups_detail(self) -> str:
         """Build detailed API groups with calling conventions summaries."""
         groups = self.group_by_service_family()
+        if not groups:
+            return self.NO_HTTP_API_MESSAGE
         detail_parts = []
 
         for group_key in sorted(groups.keys()):
@@ -2480,28 +2493,29 @@ class GenerationEngine:
             key_entry_apis = "- 暂无关键入口 API 定义"
 
         # Build endpoint index table (simplified for reference)
-        endpoint_index_lines = [
-            "| 方法 | 路径 | 模块 | 处理器 | 文档 |",
-            "|------|------|------|--------|------|",
-        ]
-        for ep in sorted(endpoints, key=lambda x: (x.get("module", ""), x.get("path", ""))):
-            method = ep.get("method", "GET")
-            path = ep.get("path", "/")
-            module_name = ep.get("module", "unknown")
-            handler = ep.get("handler", "unknown")
-            file_path = ep.get("file_path", "")
-            # Find module doc path
-            doc_link = (
-                f"[模块文档](modules/{module_name}.md)"
-                if module_name != "tests"
-                else "[测试模块](modules/tests.md)"
-            )
-            endpoint_index_lines.append(
-                f"| {method} | `{path}` | {module_name} | `{handler}` | {doc_link} |"
-            )
-        endpoint_index_table = (
-            "\n".join(endpoint_index_lines) if endpoint_index_lines else "| 无端点 | | | |"
-        )
+        if not endpoints:
+            endpoint_index_table = APIAggregator.NO_HTTP_API_MESSAGE
+        else:
+            endpoint_index_lines = [
+                "| 方法 | 路径 | 模块 | 处理器 | 文档 |",
+                "|------|------|------|--------|------|",
+            ]
+            for ep in sorted(endpoints, key=lambda x: (x.get("module", ""), x.get("path", ""))):
+                method = ep.get("method", "GET")
+                path = ep.get("path", "/")
+                module_name = ep.get("module", "unknown")
+                handler = ep.get("handler", "unknown")
+                file_path = ep.get("file_path", "")
+                # Find module doc path
+                doc_link = (
+                    f"[模块文档](modules/{module_name}.md)"
+                    if module_name != "tests"
+                    else "[测试模块](modules/tests.md)"
+                )
+                endpoint_index_lines.append(
+                    f"| {method} | `{path}` | {module_name} | `{handler}` | {doc_link} |"
+                )
+            endpoint_index_table = "\n".join(endpoint_index_lines)
 
         # =====================================================================
         # Domain-aggregated data model generation (Phase 10 - Task 10.3)

--- a/tests/test_api_aggregator.py
+++ b/tests/test_api_aggregator.py
@@ -692,3 +692,69 @@ class TestNoEndpointDump:
         is_valid, reason = validate_api_contract_grouped(aggregated_content)
         # This should pass because it has proper structure
         assert is_valid or "service/API grouping" in reason
+
+
+_FORBIDDEN_HTTP_PATHS = ("/health", "/webhook", "/items", "/ready", "/status", "/path")
+
+
+class TestEmptyEndpointState:
+    """Empty api-index must not invent HTTP contracts."""
+
+    def test_empty_build_api_groups_table_has_no_fake_inventory(self):
+        aggregator = APIAggregator(endpoints=[], modules=[])
+        table = aggregator.build_api_groups_table()
+
+        assert "| 服务族/域 |" not in table
+        assert "未扫描到 HTTP API" in table
+        for path in _FORBIDDEN_HTTP_PATHS:
+            assert path not in table
+
+    def test_empty_build_api_groups_detail_has_no_fake_inventory(self):
+        aggregator = APIAggregator(endpoints=[], modules=[])
+        detail = aggregator.build_api_groups_detail()
+
+        assert "python-backend/core-platform" not in detail
+        assert "端点数量**: 10" not in detail
+        for path in _FORBIDDEN_HTTP_PATHS:
+            assert path not in detail
+        assert "未扫描到 HTTP API" in detail or "暂无 API" in detail
+
+    def test_empty_summarize_auth_conventions_is_inapplicable(self):
+        aggregator = APIAggregator(endpoints=[], modules=[])
+        summary = aggregator.summarize_auth_conventions()
+
+        assert "Bearer" not in summary
+        assert "不适用" in summary or "未扫描到 HTTP API" in summary
+
+    def test_empty_summarize_error_conventions_has_no_status_table(self):
+        aggregator = APIAggregator(endpoints=[], modules=[])
+        summary = aggregator.summarize_error_conventions()
+
+        assert "| 401 |" not in summary
+        assert "不适用" in summary or "未扫描到 HTTP API" in summary
+
+    def test_nonempty_health_fixture_still_builds_group_table(self):
+        endpoints = [
+            {
+                "method": "GET",
+                "path": "/health",
+                "module": "api",
+                "handler": "health",
+                "file_path": "api/main.py",
+            }
+        ]
+        modules = [
+            {
+                "name": "api",
+                "domain": "api-gateway",
+                "service_family": "python-backend",
+                "runtime_role": "api-server",
+            }
+        ]
+
+        aggregator = APIAggregator(endpoints=endpoints, modules=modules)
+        table = aggregator.build_api_groups_table()
+
+        assert "| 服务族/域 |" in table
+        assert "python-backend" in table
+        assert "/health" not in table or "1" in table

--- a/tests/test_api_aggregator.py
+++ b/tests/test_api_aggregator.py
@@ -5,7 +5,9 @@ domain, and exposure pattern, and that entry-point selection uses principled
 scoring rather than just top-K retrieval.
 """
 
-from repo_wiki.generator.engine import APIAggregator, APIEndpoint
+from pathlib import Path
+
+from repo_wiki.generator.engine import APIAggregator, APIEndpoint, GenerationEngine
 
 
 class TestAPIAggregatorInitialization:
@@ -758,3 +760,53 @@ class TestEmptyEndpointState:
         assert "| 服务族/域 |" in table
         assert "python-backend" in table
         assert "/health" not in table or "1" in table
+
+    def test_build_core_context_empty_endpoints_uses_no_http_message(self, tmp_path: Path):
+        engine = GenerationEngine(tmp_path, template_root=tmp_path)
+        context = engine._build_core_context(
+            {
+                "repo_map": {"repository": {"name": "demo"}, "commands": {}},
+                "module_index": {"modules": []},
+                "api_index": {"endpoints": []},
+                "data_models": {"models": []},
+                "graph": {"modules": {}},
+            }
+        )
+
+        assert context["endpoint_index_table"] == APIAggregator.NO_HTTP_API_MESSAGE
+
+    def test_build_core_context_nonempty_endpoints_builds_index_table(self, tmp_path: Path):
+        engine = GenerationEngine(tmp_path, template_root=tmp_path)
+        context = engine._build_core_context(
+            {
+                "repo_map": {"repository": {"name": "demo"}, "commands": {}},
+                "module_index": {"modules": [{"name": "api", "path": "api"}]},
+                "api_index": {
+                    "endpoints": [
+                        {
+                            "method": "GET",
+                            "path": "/health",
+                            "module": "api",
+                            "handler": "health",
+                            "file_path": "api/main.py",
+                        },
+                        {
+                            "method": "POST",
+                            "path": "/webhook/github",
+                            "module": "tests",
+                            "handler": "handle",
+                            "file_path": "tests/api.py",
+                        },
+                    ]
+                },
+                "data_models": {"models": []},
+                "graph": {"modules": {}},
+            }
+        )
+        table = context["endpoint_index_table"]
+
+        assert table != APIAggregator.NO_HTTP_API_MESSAGE
+        assert "| 方法 | 路径 |" in table
+        assert "`/health`" in table
+        assert "[模块文档](modules/api.md)" in table
+        assert "[测试模块](modules/tests.md)" in table

--- a/tests/test_docs_api_contracts_empty.py
+++ b/tests/test_docs_api_contracts_empty.py
@@ -1,0 +1,19 @@
+"""Committed API contracts page must not invent HTTP endpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+API_CONTRACTS = ROOT / "docs" / "04-api-contracts.md"
+
+
+def test_committed_api_contracts_has_no_fake_http_inventory() -> None:
+    text = API_CONTRACTS.read_text(encoding="utf-8")
+    first_line = text.splitlines()[0]
+
+    assert "/webhook/github" not in text
+    assert "/items" not in text
+    assert "端点数 | 10" not in text
+    assert "**端点数量**: 10" not in text
+    assert "repo-agent" not in first_line


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Empty `api-index.yaml` (`endpoints: []`) no longer produces a fake HTTP inventory on `docs/04-api-contracts.md`. `APIAggregator` now returns empty-state prose that points to the `repo-wiki` CLI command surface, `ai/source-of-truth/task-catalog.yaml`, and README. The committed `docs/04-api-contracts.md` was refreshed to match. `ai/source-of-truth/api-index.yaml` is unchanged (`endpoints: []`). This does not split `init`.

Follow-up: `_build_core_context` empty `endpoints` now has a test asserting `endpoint_index_table == APIAggregator.NO_HTTP_API_MESSAGE`, plus a nonempty GET `/health` fixture covering the index-table branch.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update (typos, docs, etc.)
- [ ] Refactoring (no functional changes)
- [x] Tests (adding or updating tests)

## Related Issue
N/A

## Testing Performed
- [x] Ran tests locally: `pytest tests/test_api_aggregator.py tests/test_docs_api_contracts_empty.py tests/test_verifier.py -q`
- [x] Ran linting: `ruff format --check .`
- [x] `rg webhook/github docs/04-api-contracts.md` — no match
- [x] `src/` diff empty vs `main`

## Checklist
- [x] My code follows the project's code style
- [x] I have performed self-review
- [x] I have commented complex code areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46b4b0b6-e6da-4be7-a075-9e7dc254ce21?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46b4b0b6-e6da-4be7-a075-9e7dc254ce21&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

