### PR TITLE
chore: add OSSF Scorecard to code scanning

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,42 @@
+name: Scorecard analysis workflow
+on:
+  push:
+    branches:
+    - main
+  schedule:
+    - cron: '30 1 * * 6'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Add an official OSSF Scorecard GitHub Actions workflow so supply-chain checks (pinned actions, token permissions, branch protection, and related Scorecard results) appear on this repo’s **Security → Code scanning** alerts page alongside existing CodeQL.

The workflow writes SARIF (`results.sarif`) and uploads it with `github/codeql-action/upload-sarif`. `publish_results: true` also publishes the public Scorecard result. It uses the default `GITHUB_TOKEN` only (no PAT / `repo_token`).

Triggers:

- every **push to `main`**
- weekly schedule: Saturday 01:30 UTC (`cron: '30 1 * * 6'`)

Actions are pinned by SHA (checkout v7.0.1, scorecard-action v2.4.4, upload-artifact v7.0.1, codeql upload-sarif v4.37.4), matching the official [ossf/scorecard analysis workflow](https://github.com/ossf/scorecard/blob/main/.github/workflows/scorecard-analysis.yml).

The CodeQL query suite is being raised separately via GitHub default setup; that change is **not** part of this PR.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issue

N/A — supply-chain / code scanning enablement.

## Testing Performed

- [x] Validated workflow YAML structure and Scorecard API constraints (workflow-level `permissions: read-all`, no top-level/job `env`/`defaults`, only allowed steps, SHA pins, no `repo_token`)
- [ ] Ran tests locally: `pytest` (not applicable; workflow-only change)
- [ ] Ran linting: `ruff check .` (not applicable)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed self-review
- [x] I have commented complex code areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works (GitHub Actions workflow; verified by YAML constraint checks)
- [ ] New and existing tests pass locally (no Python/TS changes)

## Reviewer notes

Single file: `.github/workflows/scorecard.yml`. After merge, the first Scorecard SARIF upload happens on the next push to `main` or the Saturday cron. Confirm Code scanning shows a Scorecard analysis once that run completes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1e52526-5aa4-4525-843b-86331927aa87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1e52526-5aa4-4525-843b-86331927aa87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

