### PR TITLE
chore: pin Actions by SHA and declare workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,15 @@ jobs:
     name: Stage 0 contract gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
       - name: Install UV
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install dependencies
         run: uv pip install --system -e ".[dev]"
@@ -64,15 +64,15 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install UV
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install dependencies
         run: uv pip install --system -e ".[dev]"
@@ -90,7 +90,7 @@ jobs:
         run: pytest --cov=repo_wiki --cov-report=term-missing
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
@@ -99,15 +99,15 @@ jobs:
   docs-verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
       - name: Install UV
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install repo-wiki
         run: uv pip install --system -e .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ on:
         required: true
         type: string
 
+permissions: read-all
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -19,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 
@@ -52,13 +54,13 @@ jobs:
           npx vsce package --version ${{ steps.release_tag.outputs.tag }}
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: repo-wiki-browser-${{ steps.release_tag.outputs.tag }}.vsix
           path: extensions/repo-wiki-browser/*.vsix
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           draft: false
           prerelease: false
@@ -68,7 +70,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload delivery docs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: delivery-docs
           path: docs/delivery/

--- a/.github/workflows/repo-wiki-pilot.yml
+++ b/.github/workflows/repo-wiki-pilot.yml
@@ -5,6 +5,8 @@ on:
     branches: [feature/*, pilot/*]
   pull_request:
 
+permissions: read-all
+
 env:
   PROFILE: pilot
   EVIDENCE_DIR: .repo-agent-eval/pilot-${{ github.run_id }}
@@ -15,15 +17,15 @@ jobs:
     permissions: read-all
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
       - name: Install UV
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install repo-wiki
         run: uv pip install --system -e .
@@ -80,7 +82,7 @@ jobs:
           PY
 
       - name: Upload evidence bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: evidence-bundle-pilot-${{ github.run_id }}

--- a/.github/workflows/repo-wiki-strict.yml
+++ b/.github/workflows/repo-wiki-strict.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions: read-all
+
 env:
   PROFILE: strict
   EVIDENCE_DIR: .repo-agent-eval/strict-${{ github.run_id }}
@@ -16,15 +18,15 @@ jobs:
     permissions: read-all
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
       - name: Install UV
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install repo-wiki
         run: uv pip install --system -e .
@@ -52,7 +54,7 @@ jobs:
           cp compare-result.json ${{ env.EVIDENCE_DIR }}/ 2>/dev/null || echo "{}" > ${{ env.EVIDENCE_DIR }}/compare-result.json
 
       - name: Upload evidence bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: evidence-bundle-strict-${{ github.run_id }}

--- a/.github/workflows/repo-wiki-transitional.yml
+++ b/.github/workflows/repo-wiki-transitional.yml
@@ -5,6 +5,8 @@ on:
     branches: [develop, release/*]
   pull_request:
 
+permissions: read-all
+
 env:
   PROFILE: transitional
   EVIDENCE_DIR: .repo-agent-eval/transitional-${{ github.run_id }}
@@ -15,15 +17,15 @@ jobs:
     permissions: read-all
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
       - name: Install UV
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install repo-wiki
         run: uv pip install --system -e .
@@ -60,7 +62,7 @@ jobs:
           cp compare-result.json ${{ env.EVIDENCE_DIR }}/ 2>/dev/null || echo "{}" > ${{ env.EVIDENCE_DIR }}/compare-result.json
 
       - name: Upload evidence bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: evidence-bundle-transitional-${{ github.run_id }}

--- a/.github/workflows/verify-docs.yml
+++ b/.github/workflows/verify-docs.yml
@@ -5,21 +5,23 @@ on:
   push:
     branches: ["main", "master"]
 
+permissions: read-all
+
 jobs:
   verify:
     runs-on: ubuntu-latest
     permissions: read-all
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
       - name: Install UV
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install repo-wiki
         run: uv pip install --system -e .
@@ -33,7 +35,7 @@ jobs:
           cat verify-result.json
 
       - name: Upload verify result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: success() || failure()
         with:
           name: verify-result


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Pin every `uses:` in production GitHub Actions workflows to a commit SHA (keeping the current major) and declare workflow-level `permissions: read-all` where it was missing. Job-level permissions are unchanged, including `contents: write` on the release job so GitHub Releases can still be created.

This is intended to close:

- **CodeQL** `actions/unpinned-tag` alerts **#9–#17**
- **Scorecard** `PinnedDependenciesID` on `.github/workflows/*.yml`
- **Scorecard** `TokenPermissionsID` for missing top-level workflow permissions

## Type of Change

- [x] Refactoring (no functional changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (typos, docs, etc.)
- [ ] Tests (adding or updating tests)

## Related Issue

Closes CodeQL alerts #9–#17 (`actions/unpinned-tag`). Addresses Scorecard `PinnedDependenciesID` (workflow actions) and `TokenPermissionsID` (missing top-level perms).

## Out of scope (leftover Scorecard noise)

These Scorecard findings are **not** addressed in this PR:

- Unpinned tags in `tests/fixtures/**` Dockerfiles (scanner fixtures, not production)
- `BranchProtection`
- `CodeReview`
- `Fuzzing`
- `CIIBestPractices`

Also unchanged: Python/TS source, docs, Dependabot, `scorecard.yml` (already pinned), and job write scopes.

## Testing Performed

- [x] `rg "uses: .*@(v[0-9]|main|master)" .github/workflows` — no matches except trailing comments
- [x] Every `uses:` line contains a 40-char SHA
- [x] YAML still parses (`yaml.safe_load_all` on all workflow files)
- [ ] Ran tests locally: `pytest` (workflow-only change; full suite not run)
- [ ] Ran linting: `ruff check .`

## Checklist

- [x] My code follows the project's code style
- [x] I have performed self-review
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b2213e6-a9c8-4057-95d3-871a6b14ce34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b2213e6-a9c8-4057-95d3-871a6b14ce34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

