### PR TITLE
fix: survive long citation tokens, honor LLM timeout, ship templates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include repo_wiki/templates *

--- a/docs/eval/2026-08-13-flask-round1.md
+++ b/docs/eval/2026-08-13-flask-round1.md
@@ -1,0 +1,19 @@
+# Flask round-1 eval notes (2026-08-13)
+
+Target: [pallets/flask](https://github.com/pallets/flask) at SHA `2a8a38b`.
+Generator: `repo-wiki` installed with `uv tool install` of this package.
+Model: MiniMax-M3 (reasoning). No API keys recorded here.
+
+## Failures
+
+1. **`repo-wiki init` missing packaged templates.** The installed wheel did not ship `templates/`. `_template_root()` fell back to `Path(__file__).parents[2] / "templates"` (`site-packages/templates`), which does not exist. Result: `ValueError: Missing templates: docs/00-overview.md.j2, ...`.
+
+2. **`generate --profile qoder-like` crashed after composing 83 pages.** `write_generation_conflict_artifacts` → `docs_scanner.py` raised `OSError: [Errno 36] File name too long` because `_extract_claims` treated a long CHANGES.rst backtick span (prose containing `.` and `/`) as a filesystem path and called `(repo_root / p).exists()`.
+
+3. **Page compose timeout capped at 20s.** `repo-wiki.yaml` had `llm.timeout: 180`, but `_resolve_llm_page_timeout` did `min(configured_timeout, 20.0)`. MiniMax-M3 often exceeded 20s, so pages fell back.
+
+4. **`verify --profile qoder-like --ci`:** FAIL with 11 HARD findings on the partial run. Verifier HARD/SOFT thresholds were not changed in this follow-up.
+
+## Follow-up
+
+Round-2 Flask generate should run after the hardening fixes land (packaged templates, safe path claims, honor `llm.timeout` with a 300s ceiling).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,16 @@ vector = ["chromadb>=0.5.0"]
 repo-wiki = "repo_wiki.cli:app"
 
 # Explicit package discovery - only include repo_wiki package
-# Keeps ai, templates, extensions, scripts out of installed package
+# Keeps ai, templates, extensions, scripts out of installed package.
+# Jinja templates ship as package data under repo_wiki/templates (not a top-level
+# templates package), so pip/uv tool installs can resolve them via importlib.
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["repo_wiki*"]
 exclude = ["tests*", "scripts*", "ci*", "docs*", "templates*", "extensions*", "ai*"]
+
+[tool.setuptools.package-data]
+repo_wiki = ["templates/**"]
 
 [tool.uv]
 constraint-dependencies = ["idna>=3.15"]

--- a/repo_wiki/orchestration/service.py
+++ b/repo_wiki/orchestration/service.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 def _packaged_template_root() -> Path:
     """Templates shipped with the installed repo_wiki package (not site-packages/templates)."""
     resource = importlib.resources.files("repo_wiki").joinpath("templates")
-    return Path(os.fspath(resource))
+    return Path(str(resource))
 
 
 class RepoWikiService:

--- a/repo_wiki/orchestration/service.py
+++ b/repo_wiki/orchestration/service.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.resources
 import json
 import math
+import os
 import re
 import sqlite3
 import time
@@ -38,6 +40,12 @@ if TYPE_CHECKING:
     from repo_wiki.evidence.ranking import PageEvidenceBinding
     from repo_wiki.llm.config import LLMProviderConfig
     from repo_wiki.orchestration.runtime_store import EvidenceSpanRecord
+
+
+def _packaged_template_root() -> Path:
+    """Templates shipped with the installed repo_wiki package (not site-packages/templates)."""
+    resource = importlib.resources.files("repo_wiki").joinpath("templates")
+    return Path(os.fspath(resource))
 
 
 class RepoWikiService:
@@ -2227,8 +2235,6 @@ class RepoWikiService:
 
     def _resolve_llm_page_timeout(self, config: Any) -> float:
         """Bound a single real-provider page call so a bad endpoint cannot empty a run."""
-        import os
-
         raw = os.environ.get("REPO_WIKI_LLM_PAGE_TIMEOUT_SECONDS")
         if raw:
             try:
@@ -2238,7 +2244,8 @@ class RepoWikiService:
             return max(1.0, value)
 
         configured_timeout = float(getattr(config, "timeout", 60.0) or 60.0)
-        return max(1.0, min(configured_timeout, 20.0))
+        # 20s was too low for reasoning models (e.g. MiniMax-M3); keep a 300s ceiling.
+        return max(1.0, min(configured_timeout, 300.0))
 
     def _resolve_llm_max_failures(self) -> int:
         """Limit repeated provider failures before falling back for the rest of the run."""
@@ -2442,8 +2449,7 @@ class RepoWikiService:
         target_templates = self.root / "templates"
         if target_templates.exists():
             return target_templates
-        repo_templates = Path(__file__).resolve().parents[2] / "templates"
-        return repo_templates
+        return _packaged_template_root()
 
     def _sync_runtime_store(self) -> dict[str, Any]:
         """Sync document hierarchy, section registry, and nav graph to runtime sqlite.

--- a/repo_wiki/scanner/docs_scanner.py
+++ b/repo_wiki/scanner/docs_scanner.py
@@ -301,11 +301,35 @@ def _specificity(text: str) -> float:
     return min(score, 1.0)
 
 
+_PLAUSIBLE_REL_PATH = re.compile(r"^[A-Za-z0-9_./\\-]+$")
+
+
+def _is_plausible_rel_path(value: str) -> bool:
+    """Return True when value looks like a relative filesystem path, not prose."""
+    if not value or len(value) > 255:
+        return False
+    if "\0" in value or "\n" in value or "\r" in value:
+        return False
+    if not _PLAUSIBLE_REL_PATH.fullmatch(value):
+        return False
+    return "/" in value or "\\" in value or "." in value
+
+
+def _repo_path_exists(repo_root: Path, rel: str) -> bool:
+    """exists() for a claim path; OSError (ENAMETOOLONG, EINVAL) is not a file."""
+    if not _is_plausible_rel_path(rel):
+        return False
+    try:
+        return (repo_root / rel).exists()
+    except OSError:
+        return False
+
+
 def _extract_claims(text: str) -> tuple[set[str], set[str]]:
     service_like: set[str] = set()
     path_like: set[str] = set()
     for m in re.findall(r"`([^`]+)`", text):
-        if "/" in m or "." in m:
+        if _is_plausible_rel_path(m):
             path_like.add(m.lower())
         for token in re.findall(r"[A-Za-z_][A-Za-z0-9_-]{2,}", m):
             service_like.add(token.lower())
@@ -313,7 +337,8 @@ def _extract_claims(text: str) -> tuple[set[str], set[str]]:
         if token.lower().endswith(("service", "api", "model", "router")):
             service_like.add(token.lower())
     for p in re.findall(r"\b(?:src|app|repo_wiki|docs|tests)/[A-Za-z0-9_./-]+\b", text):
-        path_like.add(p.lower())
+        if _is_plausible_rel_path(p):
+            path_like.add(p.lower())
     return service_like, path_like
 
 
@@ -485,7 +510,11 @@ class DocumentationScanner:
             claim_names, claim_paths = _extract_claims(text)
 
             stale_refs = sorted(
-                [p for p in claim_paths if p not in paths and not (self.repo_root / p).exists()]
+                [
+                    p
+                    for p in claim_paths
+                    if p not in paths and not _repo_path_exists(self.repo_root, p)
+                ]
             )
             conflicting_claims = sorted(
                 [

--- a/repo_wiki/templates/docs/00-overview.md.j2
+++ b/repo_wiki/templates/docs/00-overview.md.j2
@@ -1,0 +1,56 @@
+# ${repository_name} - 项目概览
+
+${primary_cite}
+
+${project_description}
+
+## 项目定位
+
+${project_positioning}
+
+## 核心问题
+
+${core_problem}
+
+## 核心能力
+
+${core_capabilities}
+
+## 快速开始
+
+### 环境要求
+
+${environment_requirements}
+
+### 启动命令
+
+${startup_commands}
+
+## 阅读导航
+
+${reading_navigation}
+
+---
+
+## 说明
+
+${project_description}
+
+${project_positioning}
+
+${architecture_description}
+
+## 技术概览
+
+| 属性 | 值 |
+|------|-----|
+| 仓库根目录 | `${repository_root}` |
+| 主要语言 | `${primary_language}` |
+| 框架 | `${framework}` |
+| 模块数量 | ${module_count} |
+| API 端点 | ${endpoint_count} |
+| 数据模型 | ${model_count} |
+
+## 领域分组
+
+${domain_groups_markdown}

--- a/repo_wiki/templates/docs/01-architecture.md.j2
+++ b/repo_wiki/templates/docs/01-architecture.md.j2
@@ -1,0 +1,170 @@
+# ${repository_name} - 系统架构
+
+${primary_cite}
+
+${architecture_description}
+
+## 系统分层
+
+${three_layer_overview}
+
+### 三层架构图
+
+```mermaid
+graph TB
+    subgraph "Layer 1: Runtime Storage (.repo-wiki/)"
+        R1[("Index Store<br/>(SQLite + FTS)")]
+        R2[("Knowledge Graph<br/>(JSON)")]
+        R3[("Vector Cache<br/>(Chroma)")]
+        R4[("Generation Cache<br/>(SQLite)")]
+    end
+
+    subgraph "Layer 2: Source of Truth (ai/source-of-truth/)"
+        S1["module-index.yaml<br/>Module Registry"]
+        S2["api-index.yaml<br/>API Registry"]
+        S3["data-models.yaml<br/>Data Model Registry"]
+        S4["repo-map.yaml<br/>Repository Metadata"]
+        S5["task-catalog.yaml<br/>Task Definitions"]
+    end
+
+    subgraph "Layer 3: Document Center (docs/)"
+        D1["00-overview.md<br/>Project Overview"]
+        D2["01-architecture.md<br/>System Design"]
+        D3["03-module-map.md<br/>Module Map"]
+        D4["docs/sections/<br/>Section Docs"]
+        D5["docs/modules/<br/>Module Docs"]
+        D6["docs/phases/<br/>Phase Docs"]
+    end
+
+    R1 --> S1
+    R2 --> S2
+    R3 --> S3
+    S1 --> D1
+    S2 --> D3
+    S3 --> D3
+    S1 --> D4
+    S2 --> D4
+    D1 --> D2
+    D2 --> D4
+    D4 --> D5
+    D1 -.-> D6
+```
+
+## 服务协作关系
+
+${service_collaboration}
+
+### 服务交互流程
+
+```mermaid
+sequenceDiagram
+    participant Scanner
+    participant Indexer
+    participant Generator
+    participant Adapter
+    participant Docs
+
+    Scanner->>Indexer: Scan repository
+    Indexer->>Indexer: Extract modules, APIs, models
+    Indexer->>Indexer: Build knowledge graph
+    Indexer->>Indexer: Store index state
+
+    Indexer->>Generator: Source of truth (module-index, etc.)
+    Generator->>Generator: Generate overview docs
+    Generator->>Generator: Generate section docs
+    Generator->>Generator: Generate module docs
+    Generator->>Docs: Write markdown files
+
+    Adapter->>Adapter: Generate .claude/CLAUDE.md
+    Adapter->>Adapter: Generate .codex/config.toml
+```
+
+## 核心链路
+
+${core_data_flow}
+
+### 数据流图
+
+```mermaid
+flowchart LR
+    A[("Source Code<br/>Files")] --> B[("Scanner<br/>Extract")]
+    B --> C[("Indexer<br/>Transform")]
+    C --> D[("State Store<br/>Persist")]
+    C --> E[("Graph Store<br/>Persist")]
+    C --> F[("Vector Store<br/>Persist")]
+
+    D --> G[("Source of Truth<br/>yaml/json")]
+    G --> H[("Generator<br/>Template Render")]
+    H --> I[("Document Center<br/>docs/")]
+
+    F --> J[("Retrieval<br/>Query")]
+    J --> H
+```
+
+## 存储与检索设计
+
+${storage_retrieval_design}
+
+### 存储层次说明
+
+| 存储位置 | 职责 | 格式 |
+|---------|------|------|
+| `.repo-wiki/index/` | 操作知识底座 | SQLite (FTS) |
+| `.repo-wiki/graph/` | 依赖关系和影响链 | JSON |
+| `.repo-wiki/cache/` | 生成缓存 | SQLite + diskcache |
+| `ai/source-of-truth/` | 结构化事实源 | YAML |
+
+### 检索流程
+
+```mermaid
+flowchart TD
+    A[("Query")] --> B{Retrieval Strategy}
+    B -->|Vector Search| C[("Embedding<br/>Model")]
+    C --> D[("Chroma<br/>Vector DB")]
+    D --> E[("Top-K<br/>Results")]
+
+    B -->|Keyword Search| F[("FTS<br/>Full-Text")]
+    F --> E
+
+    B -->|Graph Walk| G[("Knowledge<br/>Graph")]
+    G --> E
+
+    E --> H[("Context<br/>Builder")]
+    H --> I[("LLM<br/>Generation")]
+```
+
+## 增量更新与治理闭环
+
+${incremental_governance}
+
+### 增量更新流程
+
+```mermaid
+flowchart TD
+    A[("Git Change<br/>Detection")] --> B{Impact Analysis}
+    B -->|Module Changed| C[("Expand Impacted<br/>Modules")]
+    B -->|API Changed| D[("Update<br/>API Index")]
+    B -->|Model Changed| E[("Update<br/>Model Index")]
+
+    C --> F{Regeneration<br/>Needed?}
+    F -->|Yes| G[("Regenerate<br/>Affected Docs")]
+    F -->|No| H[("Skip<br/>Generation")]
+
+    G --> I[("Verify<br/>Output Quality")]
+    I -->|Pass| J[("Commit<br/>Documentation")]
+    I -->|Fail| K[("Log<br/>Issue")]
+
+    H --> J
+```
+
+### 治理检查点
+
+${governance_checkpoints}
+
+## 模块概览
+
+${module_overview_table}
+
+## 技术栈
+
+${tech_stack}

--- a/repo_wiki/templates/docs/03-module-map.md.j2
+++ b/repo_wiki/templates/docs/03-module-map.md.j2
@@ -1,0 +1,37 @@
+# Module Map - ${repository_name}
+
+${primary_cite}
+
+本页面按业务域（Business Domain）组织模块，揭示系统的高层划分和服务家族关系。每个域内模块按运行时角色（Runtime Role）进一步分组，帮助读者理解系统的职责边界和调用关系。
+
+## 域概览
+
+${domain_overview_table}
+
+---
+
+## 详细域分组
+
+${domain_groups_detail}
+
+---
+
+## 模块索引
+
+${module_index_table}
+
+---
+
+## 跨域依赖关系
+
+${cross_domain_dependencies}
+
+---
+
+## 阅读导航
+
+- [项目概览](00-overview.md) - 快速了解项目定位和能力
+- [系统架构](01-architecture.md) - 了解三层架构设计
+- [API 契约](04-api-contracts.md) - 查看服务间接口定义
+- [数据模型](05-data-model.md) - 了解核心实体关系
+- [Section 页](sections/services/index.md) - 按服务专题深入阅读

--- a/repo_wiki/templates/docs/04-api-contracts.md.j2
+++ b/repo_wiki/templates/docs/04-api-contracts.md.j2
@@ -1,0 +1,47 @@
+# API Contracts - ${repository_name}
+
+${primary_cite}
+
+本页面按服务族（Service Family）和主题域（Domain Theme）聚合 API 端点，展示认证模式、调用约定和关键入口点。详细端点列表请参考 `ai/source-of-truth/api-index.yaml`。
+
+## 服务/API 分组
+
+${api_groups_table}
+
+---
+
+## 分组详情
+
+${api_groups_detail}
+
+---
+
+## 调用约定
+
+### 认证方式
+
+${authentication_patterns}
+
+### 错误与状态码
+
+${error_status_behavior}
+
+### 关键入口 API
+
+${key_entry_apis}
+
+---
+
+## 完整端点索引
+
+${endpoint_index_table}
+
+---
+
+## 阅读导航
+
+- [项目概览](00-overview.md) - 快速了解项目定位和能力
+- [系统架构](01-architecture.md) - 了解三层架构设计
+- [模块地图](03-module-map.md) - 查看模块依赖关系
+- [数据模型](05-data-model.md) - 了解核心实体关系
+- [Section 页](sections/api/index.md) - 按 API 专题深入阅读

--- a/repo_wiki/templates/docs/05-data-model.md.j2
+++ b/repo_wiki/templates/docs/05-data-model.md.j2
@@ -1,0 +1,61 @@
+# Data Model - ${repository_name}
+
+${primary_cite}
+
+本页面按领域聚合数据模型，展示核心实体、服务模型和持久化策略。详细模型定义请参考 `ai/source-of-truth/data-models.yaml`。
+
+## 核心数据模型
+
+${core_models_section}
+
+核心模型是跨服务共享的基础实体，定义系统的基础数据结构。
+
+### 核心模型列表
+
+${core_models_table}
+
+---
+
+## 服务数据模型
+
+${service_models_section}
+
+服务模型是特定于服务或模块的实体，封装业务逻辑所需的数据结构。
+
+### 按服务分组
+
+${service_models_by_module}
+
+---
+
+## 数据库与迁移策略
+
+${database_migration_section}
+
+### 数据库形状
+
+${database_shape}
+
+### 迁移策略
+
+${migration_strategy}
+
+### 跨模块数据边界
+
+${cross_module_boundaries}
+
+---
+
+## 模型索引
+
+${model_index_table}
+
+---
+
+## 阅读导航
+
+- [项目概览](00-overview.md) - 快速了解项目定位和能力
+- [系统架构](01-architecture.md) - 了解三层架构设计
+- [模块地图](03-module-map.md) - 查看模块依赖关系
+- [API 契约](04-api-contracts.md) - 了解服务间接口
+- [Section 页](sections/data-model/index.md) - 按数据模型专题深入阅读

--- a/repo_wiki/templates/docs/module.md.j2
+++ b/repo_wiki/templates/docs/module.md.j2
@@ -1,0 +1,33 @@
+# Module: ${module_name}
+
+Path: `${module_path}`  
+Owner: `${module_owner}`
+
+## Responsibility
+${module_responsibility}
+
+## Exports
+${module_exports}
+
+## Depends On
+${module_depends_on}
+
+## Depended By
+${module_depended_by}
+
+## Interfaces
+${module_interfaces}
+
+## Data Models
+${module_data_models}
+
+## Context Strategy
+- Strategy: `${context_strategy}`
+- Token budget: `${context_token_budget}`
+- Notes: ${context_notes}
+
+### Graph Neighbors
+${context_neighbors}
+
+### Retrieval Chunks
+${context_chunks}

--- a/repo_wiki/templates/docs/phase.md.j2
+++ b/repo_wiki/templates/docs/phase.md.j2
@@ -1,0 +1,30 @@
+# ${phase_title}
+
+{% if phase_status %}
+**Status:** ${phase_status}
+{% endif %}
+
+## Objectives
+
+${phase_objectives}
+
+## Deliverables
+
+${phase_deliverables}
+
+{% if phase_dependencies %}
+## Dependencies
+
+${phase_dependencies}
+{% endif %}
+
+## Navigation
+
+- [Overview](../00-overview.md)
+- [Architecture](../01-architecture.md)
+{% if phase_prev %}
+- [Previous: ${phase_prev_title}](../phases/${phase_prev}.md)
+{% endif %}
+{% if phase_next %}
+- [Next: ${phase_next_title}](../phases/${phase_next}.md)
+{% endif %}

--- a/repo_wiki/templates/docs/section.md.j2
+++ b/repo_wiki/templates/docs/section.md.j2
@@ -1,0 +1,37 @@
+# ${section_title}
+
+${section_description}
+
+---
+
+## 专题内容
+
+${section_content}
+
+## 模块列表
+
+${section_modules}
+
+## API 端点
+
+${section_apis}
+
+## 相关命令
+
+${section_commands}
+
+---
+
+## 导航
+
+${section_nav}
+
+---
+
+## 阅读路径
+
+${reading_paths}
+
+## 相关专题
+
+${related_sections}

--- a/repo_wiki/templates/prompt-fragments/architecture.txt.j2
+++ b/repo_wiki/templates/prompt-fragments/architecture.txt.j2
@@ -1,0 +1,7 @@
+Architecture summary for `${repository_name}`:
+${graph_summary}
+
+Prioritize context in this order:
+1. Module boundaries and dependencies
+2. API contracts
+3. Data models

--- a/repo_wiki/templates/prompt-fragments/overview.txt.j2
+++ b/repo_wiki/templates/prompt-fragments/overview.txt.j2
@@ -1,0 +1,5 @@
+Repository `${repository_name}` is built with `${primary_language}` and `${framework}`.
+Use the module map and API contracts before opening source files.
+
+Module inventory:
+${modules_table}

--- a/repo_wiki/templates/task-catalog.yaml.j2
+++ b/repo_wiki/templates/task-catalog.yaml.j2
@@ -1,0 +1,1 @@
+${task_catalog_json}

--- a/tests/test_docs_scanner_path_claims.py
+++ b/tests/test_docs_scanner_path_claims.py
@@ -1,0 +1,104 @@
+"""Safe path-claim extraction so generate does not crash on changelog prose."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from repo_wiki.scanner import docs_scanner as ds
+from repo_wiki.scanner.docs_scanner import (
+    _extract_claims,
+    scan_repository_docs_inventory,
+)
+
+# Flask CHANGES.rst-style backtick span: prose with '.' and '/' that is not a path.
+# Keep a long first path-component (text before the first '/') so a naive
+# (repo_root / excerpt).exists() raises ENAMETOOLONG on Linux.
+LONG_CHANGELOG_EXCERPT = (
+    "Flask 3.0 released with support for Python 3.8+. "
+    + ("More notes about the release. " * 16)
+    + "See also src/flask/app.py for the application object."
+)
+
+
+def _source_inventory() -> dict:
+    return {
+        "services": [],
+        "api_surfaces": [],
+        "data_models": [],
+        "frontend_callers": [],
+        "deployment_assets": [],
+        "tests": [],
+    }
+
+
+def test_long_changelog_backtick_is_not_a_plausible_path() -> None:
+    assert len(LONG_CHANGELOG_EXCERPT) > 300
+    assert "." in LONG_CHANGELOG_EXCERPT
+    assert "/" in LONG_CHANGELOG_EXCERPT
+    assert not ds._is_plausible_rel_path(LONG_CHANGELOG_EXCERPT)
+
+
+def test_extract_claims_skips_long_changelog_excerpt() -> None:
+    text = f"See notes: `{LONG_CHANGELOG_EXCERPT}`\n"
+    _names, path_like = _extract_claims(text)
+    assert LONG_CHANGELOG_EXCERPT.lower() not in path_like
+    assert not any(len(p) > 255 for p in path_like)
+
+
+def test_short_source_path_still_extracts() -> None:
+    text = "The app lives in `src/flask/app.py` and is imported at runtime.\n"
+    _names, path_like = _extract_claims(text)
+    assert "src/flask/app.py" in path_like
+    assert ds._is_plausible_rel_path("src/flask/app.py")
+
+
+def test_scan_with_changelog_excerpt_does_not_raise(tmp_path: Path) -> None:
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "changes.md").write_text(
+        f"# Changes\n\n`{LONG_CHANGELOG_EXCERPT}`\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "src" / "flask").mkdir(parents=True)
+    (tmp_path / "src" / "flask" / "app.py").write_text("app = True\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text(
+        "Entry: `src/flask/app.py`\n",
+        encoding="utf-8",
+    )
+
+    naive_raised = False
+    try:
+        (tmp_path / LONG_CHANGELOG_EXCERPT).exists()
+    except OSError:
+        naive_raised = True
+    assert naive_raised
+
+    inv = scan_repository_docs_inventory(
+        tmp_path, _source_inventory(), incremental=False, persist_cache=False
+    )
+    assert inv["documents"]
+    readme = next(d for d in inv["documents"] if d["path"].endswith("README.md"))
+    assert "src/flask/app.py" not in readme["stale_references"]
+    assert (tmp_path / "src" / "flask" / "app.py").exists()
+
+
+def test_repo_path_exists_swallows_enametoolong(tmp_path: Path) -> None:
+    huge = "a" * 300 + ".rst"
+    raised = False
+    try:
+        (tmp_path / huge).exists()
+    except OSError:
+        raised = True
+    assert raised
+    assert ds._repo_path_exists(tmp_path, huge) is False
+
+
+def test_repo_path_exists_oserror_on_plausible_path_is_missing(tmp_path: Path, monkeypatch) -> None:
+    real_exists = Path.exists
+
+    def wrapped(self: Path) -> bool:
+        if str(self).endswith("app.py"):
+            raise OSError(36, "File name too long")
+        return real_exists(self)
+
+    monkeypatch.setattr(Path, "exists", wrapped)
+    assert ds._repo_path_exists(tmp_path, "src/flask/app.py") is False

--- a/tests/test_llm_page_timeout.py
+++ b/tests/test_llm_page_timeout.py
@@ -1,0 +1,29 @@
+"""Honor configured LLM page-compose timeout instead of a 20s cap."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from repo_wiki.core.config import RepoWikiConfig
+from repo_wiki.orchestration.service import RepoWikiService
+
+
+def _service(tmp_path) -> RepoWikiService:
+    cfg = RepoWikiConfig()
+    cfg.project.root = str(tmp_path)
+    return RepoWikiService(cfg)
+
+
+def test_resolve_llm_page_timeout_honors_config(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("REPO_WIKI_LLM_PAGE_TIMEOUT_SECONDS", raising=False)
+    svc = _service(tmp_path)
+
+    assert svc._resolve_llm_page_timeout(SimpleNamespace(timeout=180)) == 180.0
+    assert svc._resolve_llm_page_timeout(SimpleNamespace(timeout=60)) == 60.0
+    assert svc._resolve_llm_page_timeout(SimpleNamespace(timeout=999)) == 300.0
+
+
+def test_resolve_llm_page_timeout_env_override(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("REPO_WIKI_LLM_PAGE_TIMEOUT_SECONDS", "12")
+    svc = _service(tmp_path)
+    assert svc._resolve_llm_page_timeout(SimpleNamespace(timeout=180)) == 12.0

--- a/tests/test_packaged_templates.py
+++ b/tests/test_packaged_templates.py
@@ -1,0 +1,33 @@
+"""Packaged Jinja templates must be available without a source checkout."""
+
+from __future__ import annotations
+
+import importlib.resources
+from pathlib import Path
+
+from repo_wiki.core.config import RepoWikiConfig
+from repo_wiki.generator.contracts import validate_contract_coverage
+from repo_wiki.orchestration.service import RepoWikiService
+
+
+def test_importlib_resources_exposes_overview_template() -> None:
+    packaged = importlib.resources.files("repo_wiki") / "templates"
+    overview = packaged / "docs" / "00-overview.md.j2"
+    assert overview.is_file()
+
+
+def test_service_template_root_without_target_templates(tmp_path: Path) -> None:
+    cfg = RepoWikiConfig()
+    cfg.project.root = str(tmp_path)
+    svc = RepoWikiService(cfg)
+
+    assert not (tmp_path / "templates").exists()
+    root = Path(svc._template_root())
+    packaged = Path(str(importlib.resources.files("repo_wiki") / "templates"))
+    assert root.resolve() == packaged.resolve()
+    assert (root / "docs" / "00-overview.md.j2").is_file()
+    assert validate_contract_coverage(root) == []
+
+    engine = svc._generation_engine()
+    assert (engine.template_root / "docs" / "00-overview.md.j2").is_file()
+    assert engine.validate_templates() == []

--- a/tests/test_packaged_templates.py
+++ b/tests/test_packaged_templates.py
@@ -31,3 +31,20 @@ def test_service_template_root_without_target_templates(tmp_path: Path) -> None:
     engine = svc._generation_engine()
     assert (engine.template_root / "docs" / "00-overview.md.j2").is_file()
     assert engine.validate_templates() == []
+
+
+def test_vendored_templates_match_repo_root_templates() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    checkout = repo_root / "templates"
+    vendored = repo_root / "repo_wiki" / "templates"
+    checkout_files = {
+        p.relative_to(checkout).as_posix(): p.read_bytes()
+        for p in checkout.rglob("*")
+        if p.is_file()
+    }
+    vendored_files = {
+        p.relative_to(vendored).as_posix(): p.read_bytes()
+        for p in vendored.rglob("*")
+        if p.is_file()
+    }
+    assert checkout_files == vendored_files


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Round-1 qoder-like generate against [pallets/flask@2a8a38b](https://github.com/pallets/flask/commit/2a8a38b) with MiniMax-M3 failed in three evidence-backed ways. Notes: `docs/eval/2026-08-13-flask-round1.md`. Round-2 Flask generate will follow after merge.

## Failures

1. **`repo-wiki init` missing packaged templates.** The installed wheel had no `templates/` (`packages.find.exclude` includes `templates*`). `_template_root()` fell back to `site-packages/templates` and raised `ValueError: Missing templates: docs/00-overview.md.j2, ...`.
2. **Generate crashed after 83 pages.** `write_generation_conflict_artifacts` → `docs_scanner.py` raised `OSError: [Errno 36] File name too long` because `_extract_claims` treated a long CHANGES.rst backtick span (prose with `.` and `/`) as a path.
3. **Page compose used `timeout=20.0s` despite `llm.timeout: 180`.** `_resolve_llm_page_timeout` did `min(configured_timeout, 20.0)`, which is too low for MiniMax-M3 reasoning and caused page fallbacks.

Verifier HARD/SOFT thresholds are unchanged. Extension src is unchanged. Flask is not vendored.

## Fixes

- **A.** `_is_plausible_rel_path` + `_repo_path_exists`: only relative path-like tokens (length ≤ 255, charset, no NUL/newlines) become filesystem claims; `exists()` OSError is treated as missing.
- **B.** Honor `llm.timeout` with a **300s** ceiling (not 20s). `REPO_WIKI_LLM_PAGE_TIMEOUT_SECONDS` still overrides (min 1, uncapped).
- **C.** Vendor Jinja templates under `repo_wiki/templates` as package data; fallback is `importlib.resources.files("repo_wiki") / "templates"`, not `site-packages/../templates`. Target-repo `templates/` still wins when present. CI asserts the two template trees stay identical. Packaged root is `Path(str(traversable))` so mypy accepts Traversable (not `os.fspath`).

## Tests

Verified locally:

```
mypy repo_wiki --ignore-missing-imports
# Success: no issues found in 123 source files

pytest tests/test_docs_scanner_path_claims.py tests/test_llm_page_timeout.py tests/test_packaged_templates.py tests/test_api_aggregator.py tests/test_docs_api_contracts_empty.py
# 40 passed

ruff format --check repo_wiki/orchestration/service.py
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dca76318-de88-438e-8d6d-ed82cc60c7ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dca76318-de88-438e-8d6d-ed82cc60c7ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

