### PR TITLE
fix: library-repo path roles, ignore init stubs, find qoder meta

### DIFF
--- a/repo_wiki/cli.py
+++ b/repo_wiki/cli.py
@@ -18,6 +18,7 @@ from repo_wiki.llm.diagnostics import (
     format_diagnostics_text,
     run_llm_diagnostics,
 )
+from repo_wiki.orchestration.latest_run_selector import select_run
 from repo_wiki.orchestration.service import RepoWikiService
 
 app = typer.Typer(help="repo-wiki: local-first repository wiki generator")
@@ -281,8 +282,6 @@ def improve_status_command(
 
 
 def _resolve_release_publish_run(output: Path, run: str | None) -> Path:
-    from repo_wiki.orchestration.latest_run_selector import select_run
-
     root = output.resolve()
     if run:
         raw = Path(run)
@@ -1228,7 +1227,13 @@ def _resolve_verify_root(project_root: Path, output: str | None) -> Path:
         return project_root
     raw = Path(output)
     if raw.exists():
-        return raw.resolve()
+        resolved = raw.resolve()
+        if (resolved / "manifest.json").is_file():
+            return resolved
+        try:
+            return select_run(resolved).resolve()
+        except ValueError:
+            return resolved
     # run-id mode: nested qoder-like layout under .repo-agent-eval/runs/<id>/
     nested = project_root / ".repo-agent-eval" / "runs" / output
     if nested.exists():
@@ -1241,8 +1246,6 @@ def _resolve_verify_root(project_root: Path, output: str | None) -> Path:
 
 
 def _resolve_improve_run(output: Path, run: str | None) -> Path:
-    from repo_wiki.orchestration.latest_run_selector import select_run
-
     root = output.resolve()
     raw = Path(run).resolve() if run and Path(run).exists() else None
     if raw:

--- a/repo_wiki/generator/engine.py
+++ b/repo_wiki/generator/engine.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+from repo_wiki.scanner.artifacts import is_product_source_path, path_role_for
 
 from .cache import GenerationCache
 from .cites import select_primary_cite
@@ -135,50 +138,47 @@ class NarrativeBuilder:
             return "library"
         return "application"
 
+    def _product_modules(self) -> list[dict[str, Any]]:
+        product: list[dict[str, Any]] = []
+        for module in self.modules:
+            path = str(module.get("path") or module.get("name") or "")
+            if path_role_for(path) is not None:
+                continue
+            product.append(module)
+        return product
+
+    def _combined_product_signals(self) -> str:
+        path_signals: list[str] = []
+        domain_signals: list[str] = []
+        for module in self._product_modules():
+            path_signals.append(str(module.get("path") or "").lower())
+            path_signals.append(" ".join(module.get("exports") or []).lower())
+            path_signals.append(str(module.get("responsibility") or "").lower())
+            domain_signals.append(str(module.get("domain") or "").lower())
+        return (
+            self.repo_name.lower() + " " + " ".join(path_signals) + " " + " ".join(domain_signals)
+        )
+
+    def _has_word_signal(self, haystack: str, signals: list[str]) -> bool:
+        return any(re.search(rf"\b{re.escape(signal)}\b", haystack) for signal in signals)
+
     def _detect_knowledge_management_signals(self) -> bool:
         """Detect if this is a knowledge management system."""
         knowledge_signals = [
             "knowledge",
             "graph",
-            "index",
             "retrieval",
             "embedding",
             "vector",
             "chroma",
             "sqlite",
         ]
-        name_lower = self.repo_name.lower()
-        path_signals = []
-        domain_signals = []
-
-        for m in self.modules:
-            path = m.get("path", "").lower()
-            path_signals.append(path)
-            exports = " ".join(m.get("exports", []) or []).lower()
-            path_signals.append(exports)
-            # Also check domain
-            domain = m.get("domain", "").lower()
-            domain_signals.append(domain)
-            # Check responsibility field too
-            resp = m.get("responsibility", "").lower()
-            path_signals.append(resp)
-
-        combined = name_lower + " " + " ".join(path_signals) + " " + " ".join(domain_signals)
-        return any(signal in combined for signal in knowledge_signals)
+        return self._has_word_signal(self._combined_product_signals(), knowledge_signals)
 
     def _detect_document_generation_signals(self) -> bool:
         """Detect if this is a document generation system."""
-        doc_signals = ["document", "wiki", "doc", "markdown", "template", "generate", "render"]
-        name_lower = self.repo_name.lower()
-        path_signals = []
-        for m in self.modules:
-            path = m.get("path", "").lower()
-            path_signals.append(path)
-            exports = " ".join(m.get("exports", []) or []).lower()
-            path_signals.append(exports)
-
-        combined = name_lower + " " + " ".join(path_signals)
-        return any(signal in combined for signal in doc_signals)
+        doc_signals = ["document", "wiki", "markdown", "template", "generate", "render"]
+        return self._has_word_signal(self._combined_product_signals(), doc_signals)
 
     def build_project_description(self) -> str:
         """Build repository-specific project description.
@@ -326,10 +326,15 @@ class NarrativeBuilder:
                 capabilities.append("命令行工具和自动化脚本")
 
         # Derive capabilities from endpoints
-        if self.endpoints:
-            api_modules = set(e.get("module", "unknown") for e in self.endpoints)
+        product_endpoints = [
+            endpoint
+            for endpoint in self.endpoints
+            if is_product_source_path(str(endpoint.get("file_path") or ""))
+        ]
+        if product_endpoints:
+            api_modules = set(e.get("module", "unknown") for e in product_endpoints)
             capabilities.append(
-                f"RESTful API 接口（{len(self.endpoints)} 个端点，跨越 {len(api_modules)} 个模块）"
+                f"RESTful API 接口（{len(product_endpoints)} 个端点，跨越 {len(api_modules)} 个模块）"
             )
 
         # Derive capabilities from data models

--- a/repo_wiki/generator/engine.py
+++ b/repo_wiki/generator/engine.py
@@ -7,8 +7,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from repo_wiki.scanner.artifacts import is_product_source_path, path_role_for
-
 from .cache import GenerationCache
 from .cites import select_primary_cite
 from .context import ContextBuilder
@@ -42,6 +40,18 @@ from .contracts import (
 )
 from .io import ensure_dir, read_yamlish, stable_hash, write_json, write_text
 from .templates import TemplateRenderer
+
+
+def _path_role_helpers() -> tuple[Any, Any]:
+    """Load product-path filters after this module finishes importing.
+
+    Importing ``repo_wiki.scanner.artifacts`` at module top executes
+    ``scanner/__init__.py`` → ``docs_scanner`` → ``orchestration`` →
+    ``service`` → this module, which raises a circular ImportError.
+    """
+    from repo_wiki.scanner.artifacts import is_product_source_path, path_role_for
+
+    return is_product_source_path, path_role_for
 
 
 @dataclass(frozen=True)
@@ -139,6 +149,7 @@ class NarrativeBuilder:
         return "application"
 
     def _product_modules(self) -> list[dict[str, Any]]:
+        path_role_for = _path_role_helpers()[1]
         product: list[dict[str, Any]] = []
         for module in self.modules:
             path = str(module.get("path") or module.get("name") or "")
@@ -326,6 +337,7 @@ class NarrativeBuilder:
                 capabilities.append("命令行工具和自动化脚本")
 
         # Derive capabilities from endpoints
+        is_product_source_path = _path_role_helpers()[0]
         product_endpoints = [
             endpoint
             for endpoint in self.endpoints

--- a/repo_wiki/orchestration/eval_layout.py
+++ b/repo_wiki/orchestration/eval_layout.py
@@ -410,9 +410,9 @@ def generate_manifest(
     }
     git_fresh = not stale_detection["is_stale"]
 
-    candidate_repowiki_zh_root = (
-        Path(target_repo) / ".repo-agent-eval" / "runs" / run_id / "repowiki" / "zh"
-    )
+    actual_zh = Path(output_dir) / "repowiki" / "zh"
+    canonical_zh = Path(target_repo) / ".repo-agent-eval" / "runs" / run_id / "repowiki" / "zh"
+    candidate_repowiki_zh_root = actual_zh if actual_zh.exists() else canonical_zh
     candidate_content_root = candidate_repowiki_zh_root / "content"
     candidate_meta_root = candidate_repowiki_zh_root / "meta"
 

--- a/repo_wiki/scanner/artifacts.py
+++ b/repo_wiki/scanner/artifacts.py
@@ -10,10 +10,40 @@ from repo_wiki.generator.io import ensure_dir, write_yamlish
 _EXCLUDED_SOURCE_OF_TRUTH_PATH_PARTS = {
     "node_modules",
     "tests",
+    "examples",
+    "tutorials",
     "fixtures",
     "fixture",
     "__pycache__",
 }
+
+# Top-level trees that may be cited as 示例/docs/tests but are not product services.
+_PATH_ROLE_BY_TOP_LEVEL: dict[str, tuple[str, str]] = {
+    "tests": ("testing", "test-harness"),
+    "test": ("testing", "test-harness"),
+    "examples": ("examples", "sample-app"),
+    "example": ("examples", "sample-app"),
+    "tutorials": ("examples", "sample-app"),
+    "docs": ("documentation", "docs"),
+}
+
+
+def path_role_for(path: str) -> tuple[str, str] | None:
+    """Return ``(domain, runtime_role)`` for non-product trees, else ``None``."""
+    parts = Path(path).parts
+    if not parts:
+        return None
+    return _PATH_ROLE_BY_TOP_LEVEL.get(parts[0].lower())
+
+
+def is_product_source_path(path: str) -> bool:
+    """Return whether a file belongs in the product HTTP API / service inventory."""
+    if not path:
+        return True
+    if path_role_for(path) is not None:
+        return False
+    return not _has_excluded_source_path(path)
+
 
 _PARSER_PSEUDO_FACT_FILES = {
     "repo_wiki/scanner/repository_scanner.py",
@@ -49,7 +79,7 @@ def should_emit_source_fact(value: Any) -> bool:
     path = _source_fact_path(value)
     if not path:
         return True
-    if _has_excluded_source_path(path):
+    if not is_product_source_path(path):
         return False
     if _is_parser_pseudo_fact(path):
         return False

--- a/repo_wiki/scanner/docs_scanner.py
+++ b/repo_wiki/scanner/docs_scanner.py
@@ -342,6 +342,33 @@ def _extract_claims(text: str) -> tuple[set[str], set[str]]:
     return service_like, path_like
 
 
+INIT_STUB_MARKER = "repo-wiki-init-stub"
+_INIT_STUB_PHRASES = (
+    "知识管理和文档生成平台",
+    "知识管理平台",
+    "RESTful API 接口（",
+)
+_INIT_STUB_EXACT_PATHS = frozenset(
+    {
+        "docs/00-overview.md",
+        "docs/01-architecture.md",
+        "docs/03-module-map.md",
+        "docs/04-api-contracts.md",
+        "docs/05-data-model.md",
+    }
+)
+
+
+def is_init_generated_doc(rel: str, text: str) -> bool:
+    """Return True for repo-wiki init placeholders, not the user's real docs."""
+    rel_n = _normalize_rel_path(rel)
+    if INIT_STUB_MARKER in text:
+        return True
+    if rel_n in _INIT_STUB_EXACT_PATHS or rel_n.startswith("docs/sections/"):
+        return any(phrase in text for phrase in _INIT_STUB_PHRASES)
+    return False
+
+
 @dataclass
 class _DocScanRecord:
     path: str
@@ -507,7 +534,14 @@ class DocumentationScanner:
                 authority_base = override.authority_score
                 authority_score_overridden = True
             spec_score = _specificity(text)
-            claim_names, claim_paths = _extract_claims(text)
+            if is_init_generated_doc(rel, text):
+                claim_names: set[str] = set()
+                claim_paths: set[str] = set()
+                authority_level = "historical"
+                authority_base = 0.1
+                authority_score_overridden = True
+            else:
+                claim_names, claim_paths = _extract_claims(text)
 
             stale_refs = sorted(
                 [

--- a/repo_wiki/scanner/multi_runtime_scanner_v3.py
+++ b/repo_wiki/scanner/multi_runtime_scanner_v3.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from repo_wiki.core.config import RepoWikiConfig
 from repo_wiki.orchestration.release_meta_schema import SCHEMA_VERSION_SOURCE_INVENTORY
+from repo_wiki.scanner.artifacts import is_product_source_path
 from repo_wiki.scanner.repository_scanner import RepositoryScanner
 
 # ---------------------------------------------------------------------------
@@ -391,6 +392,12 @@ def scan_single_file(rel: Path, text: str) -> FileScanRecord:
     # Health / probe hints in any code
     if re.search(r"(health|readiness|liveness)", text, re.I):
         record.deployment.append({"kind": "health_probe_hint", "evidence_path": rel_s})
+
+    if not is_product_source_path(rel_s):
+        if record.api_surfaces or record.services:
+            record.tests.append({"kind": "non_product_runtime", "evidence_path": rel_s})
+        record.api_surfaces = []
+        record.services = []
 
     return record
 

--- a/repo_wiki/scanner/repository_scanner.py
+++ b/repo_wiki/scanner/repository_scanner.py
@@ -26,6 +26,7 @@ from repo_wiki.core.security import (
     sanitize_text,
     should_scan,
 )
+from repo_wiki.scanner.artifacts import is_product_source_path, path_role_for
 
 _CODE_SUFFIXES = {".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".java", ".kt"}
 _MODEL_FILE_HINTS = ("model", "schema", "entity", "dto", "migration", "alembic")
@@ -509,6 +510,8 @@ class RepositoryScanner:
             suffix = file.path.suffix.lower()
             if suffix not in _CODE_SUFFIXES:
                 continue
+            if not is_product_source_path(file.path.as_posix()):
+                continue
             module_path = self._choose_module_path(file.path)
             module_name = modules[module_path].name
             text = file.text
@@ -882,6 +885,21 @@ class RepositoryScanner:
             # Combine all signals
             all_signals = f"{path_lower} {exports_lower} {interfaces_lower} {data_models_lower} {file_contents} {extensions}"
 
+            # Classify service family based on language/framework
+            service_family, sf_confidence, sf_reason = self._score_service_family(
+                all_signals, module.path, module.exports
+            )
+            module.service_family = service_family
+
+            path_role = path_role_for(module.path)
+            if path_role is not None:
+                module.domain, module.runtime_role = path_role
+                module.domain_confidence = 1.0
+                module.domain_classification_reason = (
+                    f"Path role from top-level directory '{Path(module.path).parts[0]}'"
+                )
+                continue
+
             # Classify domain
             domain, domain_confidence, domain_reason = self._score_classification(
                 all_signals, _DOMAIN_SIGNALS, "path and content"
@@ -889,12 +907,6 @@ class RepositoryScanner:
             module.domain = domain
             module.domain_confidence = domain_confidence
             module.domain_classification_reason = domain_reason
-
-            # Classify service family based on language/framework
-            service_family, sf_confidence, sf_reason = self._score_service_family(
-                all_signals, module.path, module.exports
-            )
-            module.service_family = service_family
 
             # Classify runtime role
             runtime_role, rr_confidence, rr_reason = self._score_runtime_role(

--- a/repo_wiki/templates/docs/00-overview.md.j2
+++ b/repo_wiki/templates/docs/00-overview.md.j2
@@ -1,5 +1,7 @@
 # ${repository_name} - 项目概览
 
+<!-- repo-wiki-init-stub -->
+
 ${primary_cite}
 
 ${project_description}

--- a/repo_wiki/templates/docs/section.md.j2
+++ b/repo_wiki/templates/docs/section.md.j2
@@ -1,5 +1,7 @@
 # ${section_title}
 
+<!-- repo-wiki-init-stub -->
+
 ${section_description}
 
 ---

--- a/repo_wiki/verifier/qoder_strict_verifier.py
+++ b/repo_wiki/verifier/qoder_strict_verifier.py
@@ -1616,10 +1616,33 @@ class QoderLikeVerifierService(VerifierService):
             return True
         return False
 
+    def _layout_meta_root(self) -> Path | None:
+        for candidate in (
+            self.root / "repowiki" / "zh" / "meta",
+            self.root / "meta",
+        ):
+            if candidate.is_dir():
+                return candidate
+        return None
+
     def _manifest_meta_root(self, payload: dict[str, Any]) -> Path | None:
+        layout = self._layout_meta_root()
+        if layout is not None and (
+            (layout / "quality-report.json").exists() or (layout / "page-registry.json").exists()
+        ):
+            return layout
+
         raw = payload.get("candidate_meta_root")
         if isinstance(raw, str) and raw:
-            return Path(raw)
+            declared = Path(raw)
+            if not declared.is_absolute():
+                declared = self.root / declared
+            if declared.exists() or layout is None:
+                return declared
+
+        if layout is not None:
+            return layout
+
         repowiki = payload.get("candidate_repowiki_zh_root")
         if isinstance(repowiki, str) and repowiki:
             return Path(repowiki) / "meta"

--- a/templates/docs/00-overview.md.j2
+++ b/templates/docs/00-overview.md.j2
@@ -1,5 +1,7 @@
 # ${repository_name} - 项目概览
 
+<!-- repo-wiki-init-stub -->
+
 ${primary_cite}
 
 ${project_description}

--- a/templates/docs/section.md.j2
+++ b/templates/docs/section.md.j2
@@ -1,5 +1,7 @@
 # ${section_title}
 
+<!-- repo-wiki-init-stub -->
+
 ${section_description}
 
 ---

--- a/tests/test_engine_import_cycle.py
+++ b/tests/test_engine_import_cycle.py
@@ -1,0 +1,8 @@
+"""Engine imports must not depend on scanner/orchestration package init."""
+
+
+def test_generation_engine_imports_without_circular_import() -> None:
+    from repo_wiki.generator.engine import APIAggregator, GenerationEngine
+
+    assert GenerationEngine is not None
+    assert APIAggregator is not None

--- a/tests/test_init_stub_identity.py
+++ b/tests/test_init_stub_identity.py
@@ -1,0 +1,146 @@
+"""Init-generated docs must not become the target repo's product identity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from repo_wiki.generator.engine import GenerationEngine, NarrativeBuilder
+from repo_wiki.generator.templates import TemplateRenderer
+from repo_wiki.scanner.docs_scanner import scan_repository_docs_inventory
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PACKAGED_OVERVIEW = _REPO_ROOT / "repo_wiki" / "templates" / "docs" / "00-overview.md.j2"
+_SOURCE_OVERVIEW = _REPO_ROOT / "templates" / "docs" / "00-overview.md.j2"
+
+_INVENTED_IDENTITY_PHRASES = (
+    "知识管理和文档生成平台",
+    "知识管理平台",
+    "RESTful API 接口（12 个端点）",
+    "RESTful API 接口（",
+)
+
+
+def _source_inventory() -> dict:
+    return {
+        "services": [],
+        "api_surfaces": [],
+        "data_models": [],
+        "frontend_callers": [],
+        "deployment_assets": [],
+        "tests": [],
+    }
+
+
+def test_init_overview_template_does_not_invent_product_identity() -> None:
+    for template_path in (_PACKAGED_OVERVIEW, _SOURCE_OVERVIEW):
+        text = template_path.read_text(encoding="utf-8")
+        for phrase in _INVENTED_IDENTITY_PHRASES:
+            assert phrase not in text, f"{template_path} must not hardcode {phrase!r}"
+
+
+def test_init_stub_overview_is_not_used_as_product_identity(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "lib.py").write_text("def ping():\n    return True\n", encoding="utf-8")
+    (tmp_path / "docs").mkdir()
+    stub = """# flask - 项目概览
+
+flask 是一个基于 Python (unknown) 的知识管理和文档生成平台。
+系统提供 RESTful API 接口（12 个端点）等核心能力。
+
+知识管理平台面向开发者。
+"""
+    (tmp_path / "docs" / "00-overview.md").write_text(stub, encoding="utf-8")
+    (tmp_path / "README.md").write_text(
+        "# Flask\n\nA lightweight WSGI web application framework.\n",
+        encoding="utf-8",
+    )
+
+    inventory = scan_repository_docs_inventory(
+        tmp_path, _source_inventory(), incremental=False, persist_cache=False
+    )
+    overview = next(doc for doc in inventory["documents"] if doc["path"] == "docs/00-overview.md")
+    claims = " ".join(overview.get("conflicting_claims") or [])
+    stale = " ".join(overview.get("stale_references") or [])
+    assert overview["authority_level"] not in {"source_backed"}
+    assert overview["authority_score"] < 0.5
+    assert "知识管理" not in claims
+    assert "12" not in stale
+
+    builder = NarrativeBuilder(
+        repo_name="flask",
+        primary_language="python",
+        framework="flask",
+        modules=[
+            {"name": "src", "path": "src", "domain": "unknown", "exports": ["ping"]},
+            {"name": "docs", "path": "docs", "domain": "documentation", "exports": []},
+            {
+                "name": "examples",
+                "path": "examples",
+                "domain": "examples",
+                "exports": ["index", "result"],
+            },
+        ],
+        endpoints=[],
+        models=[],
+        commands={},
+    )
+    description = builder.build_project_description()
+    capabilities = builder.build_core_capabilities()
+    for phrase in ("知识管理和文档生成平台", "知识管理平台", "RESTful API 接口"):
+        assert phrase not in description
+        assert phrase not in capabilities
+
+    engine = GenerationEngine(tmp_path, template_root=_REPO_ROOT / "templates")
+    context = engine._build_core_context(
+        {
+            "repo_map": {
+                "repository": {
+                    "name": "flask",
+                    "primary_language": "python",
+                    "framework": "flask",
+                },
+                "commands": {},
+            },
+            "module_index": {
+                "modules": [
+                    {"name": "src", "path": "src", "domain": "unknown"},
+                    {"name": "docs", "path": "docs", "domain": "documentation"},
+                ]
+            },
+            "api_index": {"endpoints": []},
+            "data_models": {"models": []},
+            "graph": {"modules": {}},
+        }
+    )
+    blob = " ".join(str(context.get(key, "")) for key in context)
+    assert "知识管理和文档生成平台" not in blob
+    assert "RESTful API 接口（12 个端点）" not in blob
+
+
+def test_rendered_init_overview_is_marked_as_placeholder(tmp_path: Path) -> None:
+    renderer = TemplateRenderer(_REPO_ROOT / "repo_wiki" / "templates")
+    content = renderer.render(
+        "docs/00-overview.md.j2",
+        {
+            "repository_name": "flask",
+            "primary_cite": "<cite>src/lib.py:1</cite>",
+            "project_description": "Placeholder description pending source-backed identity.",
+            "project_positioning": "Placeholder positioning.",
+            "architecture_description": "Placeholder architecture.",
+            "core_problem": "Placeholder problem statement.",
+            "core_capabilities": "Placeholder capabilities.",
+            "environment_requirements": "Python 3.11+",
+            "startup_commands": "See README.",
+            "reading_navigation": "Start with the README.",
+            "repository_root": str(tmp_path),
+            "primary_language": "python",
+            "framework": "flask",
+            "module_count": "1",
+            "endpoint_count": "0",
+            "model_count": "0",
+            "domain_groups_markdown": "",
+        },
+    )
+    assert "repo-wiki-init-stub" in content
+    for phrase in _INVENTED_IDENTITY_PHRASES:
+        assert phrase not in content

--- a/tests/test_path_role_product_inventory.py
+++ b/tests/test_path_role_product_inventory.py
@@ -1,0 +1,133 @@
+"""Library/framework trees must not treat tests/examples/docs as product HTTP APIs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from repo_wiki.core.config import RepoWikiConfig
+from repo_wiki.scanner.artifacts import write_source_of_truth
+from repo_wiki.scanner.multi_runtime_scanner_v3 import scan_repository_source_inventory_v3
+from repo_wiki.scanner.repository_scanner import RepositoryScanner
+
+_PRODUCT_API_ROLES = frozenset({"api-server", "api-gateway"})
+_PRODUCT_CORE_DOMAINS = frozenset({"core-platform", "api-gateway"})
+
+
+def _write_library_tree(root: Path) -> None:
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "lib.py").write_text(
+        "def add(left: int, right: int) -> int:\n    return left + right\n",
+        encoding="utf-8",
+    )
+    (root / "examples").mkdir()
+    (root / "examples" / "app.py").write_text(
+        """
+from flask import Flask
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def index():
+    return "ok"
+
+
+@app.route("/result/<id>")
+def result(id):
+    return id
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "tests").mkdir()
+    (root / "tests" / "test_app.py").write_text(
+        """
+from flask import Flask
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def test_index():
+    return "test"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "docs").mkdir()
+    (root / "docs" / "conf.py").write_text(
+        "project = 'lib'\nextensions = ['sphinx.ext.autodoc']\n# Sphinx API docs\n",
+        encoding="utf-8",
+    )
+
+
+def test_examples_tests_docs_are_not_product_api_services(tmp_path: Path) -> None:
+    _write_library_tree(tmp_path)
+    cfg = RepoWikiConfig.model_validate({"project": {"root": str(tmp_path)}})
+    snapshot = RepositoryScanner(cfg).scan()
+
+    by_path = {module.path: module for module in snapshot.modules}
+    assert (
+        "src" in by_path or "src/lib" in by_path or any("lib" in m.path for m in snapshot.modules)
+    )
+
+    for name in ("examples", "tests", "docs"):
+        module = by_path.get(name)
+        assert module is not None, f"expected {name}/ to remain a citable module"
+        assert module.runtime_role not in _PRODUCT_API_ROLES, (
+            f"{name}/ must not be a product api-server (got {module.runtime_role})"
+        )
+        assert module.domain not in _PRODUCT_CORE_DOMAINS, (
+            f"{name}/ must not be a core/api-gateway product service (got {module.domain})"
+        )
+
+    product_paths = {endpoint.path for endpoint in snapshot.endpoints}
+    assert "/" not in product_paths
+    assert "/result/<id>" not in product_paths
+    assert all(
+        "examples/" not in endpoint.file_path
+        and "tests/" not in endpoint.file_path
+        and "docs/" not in endpoint.file_path
+        for endpoint in snapshot.endpoints
+    )
+
+
+def test_product_api_index_omits_example_and_test_routes(tmp_path: Path) -> None:
+    _write_library_tree(tmp_path)
+    cfg = RepoWikiConfig.model_validate({"project": {"root": str(tmp_path)}})
+    snapshot = RepositoryScanner(cfg).scan()
+    write_source_of_truth(tmp_path, snapshot)
+
+    api_index = yaml.safe_load((tmp_path / "ai" / "source-of-truth" / "api-index.yaml").read_text())
+    endpoints = api_index.get("endpoints") or []
+    assert endpoints == []
+
+    module_index = yaml.safe_load(
+        (tmp_path / "ai" / "source-of-truth" / "module-index.yaml").read_text()
+    )
+    for module in module_index["modules"]:
+        if module["path"] in {"examples", "tests", "docs"}:
+            assert module["runtime_role"] not in _PRODUCT_API_ROLES
+            assert module["domain"] not in _PRODUCT_CORE_DOMAINS
+
+
+def test_multi_runtime_inventory_keeps_example_routes_out_of_product_apis(
+    tmp_path: Path,
+) -> None:
+    _write_library_tree(tmp_path)
+    inventory = scan_repository_source_inventory_v3(tmp_path, incremental=False)
+
+    api_paths = {
+        (item.get("path"), item.get("evidence_path")) for item in inventory["api_surfaces"]
+    }
+    assert not any(
+        evidence and ("examples/" in evidence or "tests/" in evidence or "docs/" in evidence)
+        for _path, evidence in api_paths
+    )
+    service_evidence = [item.get("evidence_path", "") for item in inventory["services"]]
+    assert not any(
+        path.startswith("examples/") or path.startswith("tests/") or path.startswith("docs/")
+        for path in service_evidence
+    )

--- a/tests/test_qoder_quality_artifact_layout.py
+++ b/tests/test_qoder_quality_artifact_layout.py
@@ -1,0 +1,118 @@
+"""Qoder-like verify must find quality artifacts where generate writes them."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from repo_wiki.cli import _resolve_verify_root
+from repo_wiki.verifier.qoder_strict_verifier import QoderLikeVerifierService
+
+_PAGE_REL = "项目概述/00-overview.md"
+
+
+def _write_quality_pair(meta_dir: Path, *, page_rel: str = _PAGE_REL) -> None:
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    (meta_dir / "quality-report.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "repo_agent.quality_report/1.0",
+                "summary": {"profile": "qoder-like", "grade": "PASS", "strict_mode": True},
+                "page_quality": [{"relative_path": page_rel, "quality_state": "READY"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (meta_dir / "page-registry.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "repo_agent.page_registry/1.0",
+                "generated_at": "2026-08-13T00:00:00Z",
+                "pages": [
+                    {
+                        "page_id": "overview",
+                        "relative_path": page_rel,
+                        "category": "overview",
+                        "page_type": "content",
+                        "quality_state": "READY",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_run_content(run_dir: Path, *, page_rel: str = _PAGE_REL) -> None:
+    page = run_dir / "repowiki" / "zh" / "content" / page_rel
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text("# Overview\n\nFlask is a WSGI framework.\n", encoding="utf-8")
+
+
+def test_verify_finds_quality_artifacts_under_repowiki_zh_meta(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run-flask"
+    _write_run_content(run_dir)
+    _write_quality_pair(run_dir / "repowiki" / "zh" / "meta")
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "version": "1.1",
+                "run_id": "run-flask",
+                "readiness_state": "READY",
+                "readiness_reasons": [],
+                "candidate_repowiki_zh_root": str(
+                    tmp_path / ".repo-agent-eval" / "runs" / "run-flask" / "repowiki" / "zh"
+                ),
+                "candidate_meta_root": str(
+                    tmp_path
+                    / ".repo-agent-eval"
+                    / "runs"
+                    / "run-flask"
+                    / "repowiki"
+                    / "zh"
+                    / "meta"
+                ),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = QoderLikeVerifierService(run_dir, strict=True).verify(ci=True)
+    assert "QODER_QUALITY_ARTIFACT_MISSING" not in result.get("hard_gate_codes", [])
+
+
+def test_verify_still_fails_when_quality_artifacts_absent(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run-empty"
+    _write_run_content(run_dir)
+    (run_dir / "repowiki" / "zh" / "meta").mkdir(parents=True)
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "version": "1.1",
+                "run_id": "run-empty",
+                "readiness_state": "READY",
+                "readiness_reasons": [],
+                "candidate_repowiki_zh_root": str(run_dir / "repowiki" / "zh"),
+                "candidate_meta_root": str(run_dir / "repowiki" / "zh" / "meta"),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = QoderLikeVerifierService(run_dir, strict=True).verify(ci=True)
+    assert "QODER_QUALITY_ARTIFACT_MISSING" in result.get("hard_gate_codes", [])
+
+
+def test_verify_output_eval_root_selects_latest_run(tmp_path: Path) -> None:
+    eval_root = tmp_path / ".repo-agent-eval"
+    older = eval_root / "run-100"
+    newer = eval_root / "run-200"
+    for run_dir, run_id in ((older, "run-100"), (newer, "run-200")):
+        run_dir.mkdir(parents=True)
+        (run_dir / "manifest.json").write_text(
+            json.dumps({"run_id": run_id, "readiness_state": "READY"}),
+            encoding="utf-8",
+        )
+
+    resolved = _resolve_verify_root(tmp_path, str(eval_root))
+    assert resolved == newer.resolve()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Flask wiki quality loop round-2 (`pallets/flask` @ `2a8a38b`, repo-wiki `98aa8bd`, MiniMax-M3) still treated tutorial/test/Sphinx trees as product HTTP APIs, cited `repo-wiki init` boilerplate as identity, and failed HARD `QODER_QUALITY_ARTIFACT_MISSING` even though generate wrote `quality-report.json` / `page-registry.json` under `repowiki/zh/meta/`.

Round-2 eval notes may land in `docs/eval/2026-08-13-flask-round2.md` (sibling PR); this change is not blocked on that file.

## Root causes (after reading the code)

1. **Path roles.** Confirmed: `RepositoryScanner._extract_endpoints` matches `@app.route` in `examples/` and `tests/`, and `_enrich_modules` scores `runtime_role=api-server` from route keywords with no path-role override. `docs/conf.py` became an `api-gateway` module via content keywords. `should_emit_source_fact` already dropped `tests/` from `api-index.yaml`, but **not** `examples/` or `docs/`, and module-index still registered those trees as core services. Multi-runtime v3 also promoted `Flask(` in examples into `services`.
2. **Init stubs.** Confirmed, plus a generator-side cause: `NarrativeBuilder` treated substring `doc` in `docs` and export name `index` (tutorial handlers) as “知识管理 + 文档生成”, so init wrote `docs/00-overview.md` with invented identity; `docs_scanner` then extracted claims from that file as SOT.
3. **Quality artifacts.** Confirmed with a layout mismatch: `generate_manifest` hardcoded `candidate_meta_root` to `{target}/.repo-agent-eval/runs/<id>/repowiki/zh/meta` even when `--output` materialized the run at `{output}/<id>/repowiki/zh/meta`. The verifier trusted `candidate_meta_root` and did not look at the run directory’s `repowiki/zh/meta/`.

## Fixes

- Top-level `tests/` / `examples/` / `docs/` get path roles (`testing`/`test-harness`, `examples`/`sample-app`, `documentation`/`docs`). Those files stay citable as modules/示例, but they no longer populate the product HTTP API inventory or product services.
- Init overview/section templates are marked `<!-- repo-wiki-init-stub -->`. Scanner/generator skip those placeholders (and existing stubs that still contain the invented identity phrases) from product claims. Real user docs are not deleted.
- Verifier prefers existing `repowiki/zh/meta` artifacts on the verify root. Manifest generation records the actual run `repowiki/zh` tree when it exists. Missing artifacts still HARD-fail; thresholds are unchanged.
- One-line residual: `verify --output <eval-root>` now selects the latest run (lexicographic `select_run`) instead of binding the eval root itself.

Not in this PR: MiniMax HTTP 529 emptying pages.

## Tests

- `tests/test_path_role_product_inventory.py`
- `tests/test_init_stub_identity.py`
- `tests/test_qoder_quality_artifact_layout.py`
- Related: `tests/test_api_aggregator.py`, `tests/test_docs_api_contracts_empty.py`, scanner/verifier/narrative/init-template tests

`ruff format --check .` and `mypy repo_wiki --ignore-missing-imports` are green. No Flask clone. No threshold loosening. No extra SAST. No secrets.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bef7909-454d-47f2-bcbb-00158ef7dd0c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bef7909-454d-47f2-bcbb-00158ef7dd0c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

