### PR TITLE
fix: retry transient LLM 529/429 instead of empty pages

### DIFF
--- a/repo_wiki/generator/composer.py
+++ b/repo_wiki/generator/composer.py
@@ -28,6 +28,7 @@ from repo_wiki.evidence.ranking import PageEvidenceBinding
 from repo_wiki.llm.config import LLMProviderConfig
 from repo_wiki.llm.models import ChatMessage, ChatRequest, ChatResponse, LLMProvider
 from repo_wiki.llm.providers import create_mock_provider
+from repo_wiki.llm.retry import chat_with_retry
 from repo_wiki.planner.schema import INVENTORY_SERVICE_API_PAGE_ID, WikiPagePlan
 from repo_wiki.prompts.contracts import (
     PagePromptContract,
@@ -600,7 +601,7 @@ class LLMPageComposer:
             timeout=self._llm_config.timeout,
         )
 
-        return await self._provider.chat(request)
+        return await chat_with_retry(self._provider, request)
 
     def _resolve_request_max_tokens(self) -> int:
         raw = os.environ.get("REPO_WIKI_LLM_COMPOSER_MAX_TOKENS")

--- a/tests/test_llm_compose_retry.py
+++ b/tests/test_llm_compose_retry.py
@@ -1,0 +1,203 @@
+"""Tests that page composition retries transient LLM 5xx/429 instead of emptying pages."""
+
+from __future__ import annotations
+
+import pytest
+
+from repo_wiki.generator.composer import (
+    ComposerContext,
+    build_composer_input,
+    create_composer,
+)
+from repo_wiki.llm.config import LLMProviderConfig
+from repo_wiki.llm.models import (
+    ChatRequest,
+    ChatResponse,
+    ErrorCode,
+    LLMProvider,
+    NonRetryableError,
+    ProviderCapabilities,
+    RetryableError,
+)
+from repo_wiki.llm.retry import RetryConfig
+from repo_wiki.planner.schema import WikiPagePlan, WikiTaxonomyCategory
+
+SUCCESS_MARKDOWN = "# Sample Page\n\nRetried LLM content with enough prose for validation."
+
+
+def _retryable(status: int) -> RetryableError:
+    code = ErrorCode.RATE_LIMIT if status == 429 else ErrorCode.SERVER_ERROR
+    return RetryableError(
+        message=f"Server error: {status}",
+        code=code,
+        details={"status": status},
+    )
+
+
+def _success_response() -> ChatResponse:
+    return ChatResponse(content=SUCCESS_MARKDOWN, model="mock-gpt")
+
+
+class SequenceLLMProvider(LLMProvider):
+    """Fake provider that yields a scripted sequence of errors or responses."""
+
+    def __init__(self, outcomes: list[Exception | ChatResponse]) -> None:
+        self._outcomes = list(outcomes)
+        self._call_count = 0
+        self._config = LLMProviderConfig(provider="mock", model="mock-gpt")
+
+    @property
+    def name(self) -> str:
+        return "sequence-fake"
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities()
+
+    @property
+    def call_count(self) -> int:
+        return self._call_count
+
+    async def chat(self, request: ChatRequest) -> ChatResponse:
+        self._call_count += 1
+        if self._call_count > 20:
+            raise AssertionError("retry loop exceeded guard; expected RetryConfig.max_retries")
+        if not self._outcomes:
+            raise AssertionError("SequenceLLMProvider called more times than outcomes provided")
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    def validate_config(self) -> list[tuple[str, str | None, str]]:
+        return []
+
+
+class AlwaysRetryableProvider(LLMProvider):
+    """Fake provider that always raises a retryable HTTP error."""
+
+    def __init__(self, status: int = 529) -> None:
+        self._status = status
+        self._call_count = 0
+        self._config = LLMProviderConfig(provider="mock", model="mock-gpt")
+
+    @property
+    def name(self) -> str:
+        return "always-retryable-fake"
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities()
+
+    @property
+    def call_count(self) -> int:
+        return self._call_count
+
+    async def chat(self, request: ChatRequest) -> ChatResponse:
+        self._call_count += 1
+        if self._call_count > 20:
+            raise AssertionError("retry loop exceeded guard; expected RetryConfig.max_retries")
+        raise _retryable(self._status)
+
+    def validate_config(self) -> list[tuple[str, str | None, str]]:
+        return []
+
+
+@pytest.fixture
+def sample_page() -> WikiPagePlan:
+    return WikiPagePlan(
+        page_id="sample-page",
+        title="Sample Page",
+        category=WikiTaxonomyCategory.PROJECT_OVERVIEW,
+        output_path="docs/sample.md",
+    )
+
+
+@pytest.fixture
+def sample_context() -> ComposerContext:
+    return ComposerContext(
+        repository_name="test-repo",
+        primary_language="python",
+        framework="pytest",
+        repository_root=".",
+    )
+
+
+@pytest.fixture
+def no_retry_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _instant(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("repo_wiki.llm.retry.asyncio.sleep", _instant)
+
+
+@pytest.mark.asyncio
+async def test_compose_page_retries_http_529_then_succeeds(
+    sample_page: WikiPagePlan,
+    sample_context: ComposerContext,
+    no_retry_sleep: None,
+) -> None:
+    provider = SequenceLLMProvider(
+        [_retryable(529), _retryable(529), _success_response()],
+    )
+    composer = create_composer(provider=provider)
+    output = await composer.compose_page(build_composer_input(sample_page, None, sample_context))
+
+    assert output.rejected is False
+    assert output.markdown
+    assert "LLM composer did not return content" not in output.markdown
+    assert provider.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_compose_page_retries_http_429_then_succeeds(
+    sample_page: WikiPagePlan,
+    sample_context: ComposerContext,
+    no_retry_sleep: None,
+) -> None:
+    provider = SequenceLLMProvider(
+        [_retryable(429), _retryable(429), _success_response()],
+    )
+    composer = create_composer(provider=provider)
+    output = await composer.compose_page(build_composer_input(sample_page, None, sample_context))
+
+    assert output.rejected is False
+    assert output.markdown
+    assert "LLM composer did not return content" not in output.markdown
+    assert provider.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_compose_page_does_not_retry_http_401(
+    sample_page: WikiPagePlan,
+    sample_context: ComposerContext,
+    no_retry_sleep: None,
+) -> None:
+    auth_error = NonRetryableError(
+        message="Authentication failed",
+        code=ErrorCode.AUTH_FAILURE,
+        details={"status": 401},
+    )
+    provider = SequenceLLMProvider([auth_error, _success_response()])
+    composer = create_composer(provider=provider)
+    output = await composer.compose_page(build_composer_input(sample_page, None, sample_context))
+
+    assert output.rejected is True
+    assert output.markdown == ""
+    assert provider.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_compose_page_rejects_after_retries_exhausted(
+    sample_page: WikiPagePlan,
+    sample_context: ComposerContext,
+    no_retry_sleep: None,
+) -> None:
+    provider = AlwaysRetryableProvider(status=529)
+    composer = create_composer(provider=provider)
+    output = await composer.compose_page(build_composer_input(sample_page, None, sample_context))
+
+    assert output.rejected is True
+    assert "529" in (output.rejection_reason or "")
+    assert provider.call_count == RetryConfig().max_retries + 1
+    assert provider.call_count <= 20


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Flask wiki round-2 (`pallets/flask` @ 2a8a38b, repo-wiki `98aa8bd`, MiniMax-M3) composed 84 pages; **22 fell back with `Server error: 529`** and `provider_disabled_after_failures=true`; 42 pages contained “LLM composer did not return content”.

Root cause: adapters already map HTTP `>= 500` and `429` to `RetryableError`, and `chat_with_retry` already implements exponential backoff, but `LLMPageComposer._call_llm` called `provider.chat` once. `compose_page` then wrapped that exception as `ComposerOutput(rejected=True, markdown="")`.

This PR wires `_call_llm` to `chat_with_retry` (`RetryConfig.max_retries` default remains 3). After retries are exhausted, the existing rejected/fallback path is unchanged.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (adding or updating tests)

## Testing Performed
- [x] TDD: wrote failing tests first, then the one-line production change
- [x] `pytest tests/test_llm_compose_retry.py tests/test_llm_page_composer.py tests/test_llm_retry_cache.py`
- [x] `ruff format --check .`
- [x] `mypy repo_wiki --ignore-missing-imports`

New tests in `tests/test_llm_compose_retry.py` (CI fixtures only, no network):

1. **529 then success** — `RetryableError` status 529 twice, then `ChatResponse`; `compose_page` succeeds with non-empty markdown; provider called 3 times
2. **429 then success** — same pattern with status 429
3. **401 is not retried** — `NonRetryableError` fails immediately (one call)
4. **Retries exhausted** — all calls 529 → rejected after `RetryConfig.max_retries + 1` attempts (default 3 retries, 4 calls); no infinite loop

## Checklist
- [x] Smallest production change (`_call_llm` → `chat_with_retry`)
- [x] Did not clone Flask or FastAPI
- [x] Did not loosen verifier thresholds
- [x] Did not commit secrets
- [x] Do not merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06f9623d-9610-4870-ad12-d1f750ba5263?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06f9623d-9610-4870-ad12-d1f750ba5263&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

