### PR TITLE
docs: FastAPI RealWorld round-1 wiki quality eval

### DIFF
--- a/docs/eval/2026-08-13-fastapi-realworld-round1-verify.json
+++ b/docs/eval/2026-08-13-fastapi-realworld-round1-verify.json
@@ -1,0 +1,40 @@
+{
+  "grade": "FAIL",
+  "profile": "qoder-like",
+  "exit_code": 1,
+  "status": "NOT_READY",
+  "fastapi_sha": "029eb7781c60d5f563ee8990a0cbfb79b244538c",
+  "repo_wiki_sha": "9cadf853858cbd4cbf19b0eb568b92c7562ebafc",
+  "model": "MiniMax-M3",
+  "summary": {
+    "total": 25,
+    "pass": 13,
+    "warn": 0,
+    "fail": 12,
+    "hard_gate_failures": 12,
+    "soft_gate_failures": 0
+  },
+  "hard_gate_codes": [
+    "QODER_MANIFEST_PATH_INVALID",
+    "QODER_PAGE_QUALITY_STATE_MISSING",
+    "QODER_UNRESOLVED_FACT_CONFLICT",
+    "QODER_REQUIRED_INVENTORY_MISSING",
+    "QODER_CITATION_INVALID",
+    "QODER_CITATION_FACT_COVERAGE_LOW",
+    "QODER_OWNER_COVERAGE_MISSING",
+    "QODER_CITATION_RELEVANCE_MISMATCH",
+    "QODER_API_MERMAID_MISSING",
+    "QODER_DATA_MODEL_ER_MERMAID_MISSING",
+    "QODER_PAGE_DUMP",
+    "QODER_DIRTY_WORKTREE"
+  ],
+  "notes": {
+    "pages": 89,
+    "empty_llm_shells": 60,
+    "invalid_citations": 22,
+    "claim_coverage": "43.50%",
+    "unresolved_fact_conflicts": 74,
+    "llm_529": 0,
+    "fallback_page_count": 0
+  }
+}

--- a/docs/eval/2026-08-13-fastapi-realworld-round1.md
+++ b/docs/eval/2026-08-13-fastapi-realworld-round1.md
@@ -1,0 +1,59 @@
+# FastAPI RealWorld 对照 Wiki 第一轮评测
+
+**对照仓：** nsidnev/fastapi-realworld-example-app `029eb7781c60d5f563ee8990a0cbfb79b244538c`  
+**模型：** MiniMax-M3（openai-compat `https://api.minimaxi.com/v1`）  
+**超时：** YAML 180s；无 HTTP 529/429  
+**并发：** 2  
+**CLI：** repo-wiki @ `9cadf853858cbd4cbf19b0eb568b92c7562ebafc`（PR #40）  
+**时间：** 2026-08-13 22:07–22:18 CST（compose 675s）  
+**verify JSON：** `docs/eval/2026-08-13-fastapi-realworld-round1-verify.json`
+
+## 生成结果
+
+| 项 | 值 |
+|---|---|
+| generate | success，89/89 页 |
+| 529 / 429 | 0 / 0（#40 retry 未触发） |
+| fallback | 0；provider 未熔断 |
+| “LLM composer did not return content” | **60 / 89**（HTTP 200 + 空 content，仍记 PASS） |
+| index | modules=9，endpoints=11，data_models=29 |
+
+空壳机制：compact prompt 把 `max_tokens` cap 在 1400；MiniMax-M3 推理输出常把 `message.content` 留空；`chat_with_retry` 不把空内容当 retryable。
+
+## Verify
+
+run-scoped：`verify --profile qoder-like --ci --output run-1786630053017`
+
+| | FastAPI r1 | Flask r2 |
+|---|---|---|
+| HARD / SOFT | 12 / 0 | 12 / 0 |
+| claim coverage | 43.50% | 15.06% |
+| 无效 citation | 22 | 31 |
+| API aggregation | PASS 9/13 | FAIL 8/14 |
+
+HARD：`QODER_MANIFEST_PATH_INVALID`（`run-*` vs `runs/<run>`）、duplicate quality entries、74 fact conflicts、缺 apis/models/runtimes 库存、citation/coverage/owner、API/ER mermaid、page dump、dirty-worktree。未放宽阈值。
+
+## Rubric（事实/证据/结构/边界）
+
+| 页 | 事实 | 证据 | 结构 | 边界 | 注 |
+|---|---|---|---|---|---|
+| 项目概述 | 0 | 1 | 1 | 0 | 未称知识管理平台（#39）。未识别 Conduit。叙事是 api-gateway 平台 |
+| 整体架构 | 0 | 1 | 0 | 0 | 空壳 |
+| 模块关系 | 1 | 2 | 1 | 0 | ArticlesRepository 对；mermaid 含 docs/tests |
+| API参考 | 1 | 1 | 0 | 2 | 未编造 /health；UNRESOLVED；缺 /users /articles 前缀 |
+| 数据模型 | 1 | 1 | 0 | 1 | 总览空壳；子页有 User/Article/Comment/Tag |
+
+## 幻觉（摘要）
+
+- 把仓库说成 api-gateway 平台，而不是 Conduit users/articles
+- 把 init 的 AGENTS.md / repo-wiki 命令当产品
+- 04 UNRESOLVED，尽管已有 11 条扫描端点
+- handler 错绑：list_articles → DELETE /{slug}
+- POST /login 缺 /users 前缀；GET /feed 缺 /articles
+
+## 建议修（本 PR 不改代码）
+
+1. 空 content 当 retryable；抬高 reasoning 模型 max_tokens
+2. FastAPI include_router prefix + 按装饰器绑 handler
+3. 有产品 endpoints 时禁止 04 UNRESOLVED
+4. 降权 AGENTS.md / init stub

--- a/docs/eval/2026-08-13-fastapi-realworld-wrap.md
+++ b/docs/eval/2026-08-13-fastapi-realworld-wrap.md
@@ -1,0 +1,10 @@
+# FastAPI RealWorld wiki 质量对照 wrap
+
+**日期：** 2026-08-13 CST  
+**对照：** nsidnev/fastapi-realworld-example-app `029eb778` × MiniMax-M3 × repo-wiki `9cadf85`（PR #40）
+
+- generate 成功：89 页，0 次 529，0 fallback。
+- 新主伤：60/89 空壳（HTTP 200 + 空 content，compact 1400）。
+- PR #39：概述不再自称知识管理平台；污染换成 AGENTS.md。
+- 04 没编造 /health，也没写出 /users/login、/articles 完整前缀。scanner 11 条相对 path 且 handler 错绑。
+- verify 12 HARD / 0 SOFT。不要松阈值。generator-fix 另开 PR。

--- a/docs/eval/2026-08-13-flask-loop-wrapup.md
+++ b/docs/eval/2026-08-13-flask-loop-wrapup.md
@@ -17,4 +17,4 @@
 
 ## 第三语料建议
 
-**要，且应是小型 FastAPI 应用（不是 fastapi/fastapi）。** 本 wrap-up **不启动** 该语料。不要 push pallets/flask，不要把 Flask 加为 submodule。
+**要，且应是小型 FastAPI 应用（不是 fastapi/fastapi）。** FastAPI RealWorld 第一轮评测见 `docs/eval/2026-08-13-fastapi-realworld-round1.md`。不要 push pallets/flask，不要把 Flask 加为 submodule。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Add FastAPI RealWorld round-1 wiki quality eval artifacts under `docs/eval/`. This records MiniMax-M3 generate/verify results against `nsidnev/fastapi-realworld-example-app` at `029eb778`. No generator code, secrets, wiki dumps, or FastAPI submodule are included.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update (typos, docs, etc.)
- [ ] Refactoring (no functional changes)
- [ ] Tests (adding or updating tests)

## Related Issue

N/A — eval artifact drop after Flask round-2 (`#38`) and generator PRs `#39` / `#40`.

## Files

- `docs/eval/2026-08-13-fastapi-realworld-round1.md` — round-1 rubric, hallucinations, suggested generator fixes (not implemented here)
- `docs/eval/2026-08-13-fastapi-realworld-wrap.md` — short wrap
- `docs/eval/2026-08-13-fastapi-realworld-round1-verify.json` — redacted verify summary (`FAIL`, 12 HARD / 0 SOFT)
- `docs/eval/2026-08-13-flask-loop-wrapup.md` — one-line pointer to the FastAPI eval

## Findings (for reviewers)

- generate: 89/89 pages, 0 HTTP 529/429, 0 fallback
- 60/89 empty LLM shells (HTTP 200 + empty `message.content`; still counted PASS)
- verify: 12 HARD / 0 SOFT; claim coverage 43.50%; do not loosen thresholds
- Suggested generator fixes belong in a separate PR

## Testing Performed
- [ ] Ran tests locally: `pytest`
- [ ] Ran linting: `ruff check .`

Docs-only; no generator or CLI changes.

## Checklist
- [x] My code follows the project's code style
- [x] I have performed self-review
- [ ] I have commented complex code areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df0f61bd-d2b4-484a-93a7-793c50df421f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df0f61bd-d2b4-484a-93a7-793c50df421f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

