### PR TITLE
fix: retry empty LLM content and stop compact 1400 starving reasoning models

### DIFF
--- a/repo_wiki/generator/composer.py
+++ b/repo_wiki/generator/composer.py
@@ -603,17 +603,34 @@ class LLMPageComposer:
 
         return await chat_with_retry(self._provider, request)
 
+    def _uses_compact_mock_token_cap(self) -> bool:
+        """Keep the compact 1400 completion cap for mock/tests only.
+
+        Real providers (MiniMax-M3, OpenAI, ...) must not share that cap:
+        reasoning models spend tokens on hidden reasoning, and 1400 leaves
+        ``message.content`` empty. Mock fixtures stay cheap.
+        """
+        config_provider = str(self._llm_config.provider or "").strip().lower()
+        resolved_name = str(getattr(self._provider, "name", "") or "").strip().lower()
+        return config_provider in {"mock", "test"} or resolved_name in {"mock", "test"}
+
     def _resolve_request_max_tokens(self) -> int:
+        configured = self._llm_config.max_tokens
+        provider_max = int(
+            getattr(self._provider.capabilities, "max_context_tokens", configured) or configured
+        )
         raw = os.environ.get("REPO_WIKI_LLM_COMPOSER_MAX_TOKENS")
         if raw:
             try:
                 value = int(raw)
             except ValueError:
                 value = 1400
-            return max(256, min(value, self._llm_config.max_tokens))
-        if self._use_compact_prompt():
-            return min(self._llm_config.max_tokens, 1400)
-        return self._llm_config.max_tokens
+            return max(256, min(value, configured, provider_max))
+        if self._use_compact_prompt() and self._uses_compact_mock_token_cap():
+            return max(256, min(configured, 1400))
+        # Real providers: use configured llm.max_tokens, or at least 4096, still
+        # <= provider max. Compact prompt must not clamp these to 1400.
+        return max(256, min(max(configured, 4096), provider_max))
 
     def _normalize_markdown_response(self, content: str, title: str) -> str:
         """Ensure provider output is a readable Markdown page."""

--- a/repo_wiki/llm/models.py
+++ b/repo_wiki/llm/models.py
@@ -41,6 +41,7 @@ class ErrorCode(str, Enum):
     RATE_LIMIT = "RATE_LIMIT"
     SERVER_ERROR = "SERVER_ERROR"
     NETWORK_ERROR = "NETWORK_ERROR"
+    EMPTY_CONTENT = "EMPTY_CONTENT"
 
     # Non-retryable errors
     AUTH_FAILURE = "AUTH_FAILURE"

--- a/repo_wiki/llm/retry.py
+++ b/repo_wiki/llm/retry.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any, TypeVar
 
 import repo_wiki.llm
-from repo_wiki.llm.models import LLMProvider, RetryableError
+from repo_wiki.llm.models import ErrorCode, LLMProvider, RetryableError
 
 T = TypeVar("T")
 
@@ -92,12 +92,21 @@ async def with_retry(
         raise last_error
 
 
+def assistant_content_is_empty(content: str | None) -> bool:
+    """Return True when assistant content is missing, empty, or whitespace-only."""
+    return not str(content or "").strip()
+
+
 async def chat_with_retry(
     provider: LLMProvider,
     request: repo_wiki.llm.ChatRequest,
     retry_config: RetryConfig | None = None,
 ) -> repo_wiki.llm.ChatResponse:
     """Send a chat request with retry logic.
+
+    HTTP 200 responses with empty/whitespace assistant ``content`` are treated as
+    ``RetryableError`` (MiniMax-M3 and similar reasoning models can spend the
+    token budget on hidden reasoning and return a blank ``content`` field).
 
     Args:
         provider: LLM provider
@@ -110,8 +119,21 @@ async def chat_with_retry(
     Raises:
         RetryableError: If all retries exhausted
     """
+
+    async def _chat_rejecting_empty_content(
+        chat_request: repo_wiki.llm.ChatRequest,
+    ) -> repo_wiki.llm.ChatResponse:
+        response = await provider.chat(chat_request)
+        if assistant_content_is_empty(response.content):
+            raise RetryableError(
+                message="Empty LLM assistant content",
+                code=ErrorCode.EMPTY_CONTENT,
+                details={"status": 200},
+            )
+        return response
+
     return await with_retry(
-        provider.chat,
+        _chat_rejecting_empty_content,
         request,
         retry_config=retry_config,
         provider=provider,

--- a/tests/test_llm_compose_retry.py
+++ b/tests/test_llm_compose_retry.py
@@ -38,6 +38,11 @@ def _success_response() -> ChatResponse:
     return ChatResponse(content=SUCCESS_MARKDOWN, model="mock-gpt")
 
 
+def _empty_response(content: str = "") -> ChatResponse:
+    """HTTP 200 ChatResponse with blank/whitespace assistant content."""
+    return ChatResponse(content=content, model="mock-gpt")
+
+
 class SequenceLLMProvider(LLMProvider):
     """Fake provider that yields a scripted sequence of errors or responses."""
 
@@ -201,3 +206,58 @@ async def test_compose_page_rejects_after_retries_exhausted(
     assert "529" in (output.rejection_reason or "")
     assert provider.call_count == RetryConfig().max_retries + 1
     assert provider.call_count <= 20
+
+
+@pytest.mark.asyncio
+async def test_compose_page_retries_empty_content_then_succeeds(
+    sample_page: WikiPagePlan,
+    sample_context: ComposerContext,
+    no_retry_sleep: None,
+) -> None:
+    """HTTP 200 with blank/whitespace content is retryable, like 5xx/429."""
+    provider = SequenceLLMProvider(
+        [_empty_response(""), _empty_response("  \n\t"), _success_response()],
+    )
+    composer = create_composer(provider=provider)
+    output = await composer.compose_page(build_composer_input(sample_page, None, sample_context))
+
+    assert output.rejected is False
+    assert SUCCESS_MARKDOWN.splitlines()[0] in output.markdown
+    assert "LLM composer did not return content" not in output.markdown
+    assert provider.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_compose_page_rejects_after_empty_content_retries_exhausted(
+    sample_page: WikiPagePlan,
+    sample_context: ComposerContext,
+    no_retry_sleep: None,
+) -> None:
+    """Exhausted empty-content retries must fail, not PASS with a placeholder shell."""
+    provider = SequenceLLMProvider([_empty_response("") for _ in range(10)])
+    composer = create_composer(provider=provider)
+    output = await composer.compose_page(build_composer_input(sample_page, None, sample_context))
+
+    assert output.rejected is True
+    assert output.rejection_reason
+    assert not (
+        output.rejected is False and "LLM composer did not return content" in output.markdown
+    )
+    assert "LLM composer did not return content" not in output.markdown
+    assert provider.call_count == RetryConfig().max_retries + 1
+    assert provider.call_count <= 20
+
+
+@pytest.mark.asyncio
+async def test_compose_page_does_not_retry_nonempty_content(
+    sample_page: WikiPagePlan,
+    sample_context: ComposerContext,
+    no_retry_sleep: None,
+) -> None:
+    provider = SequenceLLMProvider([_success_response(), _empty_response("")])
+    composer = create_composer(provider=provider)
+    output = await composer.compose_page(build_composer_input(sample_page, None, sample_context))
+
+    assert output.rejected is False
+    assert "LLM composer did not return content" not in output.markdown
+    assert provider.call_count == 1

--- a/tests/test_llm_page_composer.py
+++ b/tests/test_llm_page_composer.py
@@ -32,6 +32,7 @@ from repo_wiki.generator.composer import (
     create_composer,
     run_smoke_test,
 )
+from repo_wiki.llm.config import LLMProviderConfig
 from repo_wiki.llm.providers import MockLLMProvider, create_mock_provider
 from repo_wiki.orchestration.runtime_store import EvidenceSpanRecord
 from repo_wiki.orchestration.service import RepoWikiService
@@ -43,6 +44,14 @@ from repo_wiki.planner.schema import (
 )
 from repo_wiki.prompts.contracts import PagePromptContract, PagePromptType
 from repo_wiki.prompts.skeleton import build_skeleton
+
+
+class _NamedMockProvider(MockLLMProvider):
+    """Mock chat implementation that reports a real provider name (e.g. minimax)."""
+
+    @property
+    def name(self) -> str:
+        return self._config.provider
 
 
 class TestCitationPreservationValidator:
@@ -327,6 +336,39 @@ class TestLLMPageComposer:
         composer = create_composer()
         assert composer is not None
         assert composer._provider is not None
+
+    def test_real_provider_compact_max_tokens_not_clamped_to_1400(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Compact prompt must not cap real providers at 1400 (starves MiniMax-M3 reasoning).
+
+        Split: mock/tests may keep a compact 1400 cap; real-looking configs use
+        configured llm.max_tokens (or at least 4096), still <= provider max.
+        """
+        monkeypatch.setenv("REPO_WIKI_COMPACT_LLM_PROMPT", "1")
+        monkeypatch.delenv("REPO_WIKI_LLM_COMPOSER_MAX_TOKENS", raising=False)
+        llm_config = LLMProviderConfig(
+            provider="minimax",
+            model="MiniMax-M3",
+            max_tokens=8192,
+        )
+        provider = _NamedMockProvider(config=llm_config)
+        composer = create_composer(provider=provider, llm_config=llm_config)
+        resolved = composer._resolve_request_max_tokens()
+        assert resolved != 1400
+        assert resolved == 8192
+        assert resolved >= 4096
+        assert resolved <= llm_config.max_tokens
+
+    def test_mock_provider_compact_max_tokens_keeps_small_cap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Mock/tests may keep the compact 1400 cap so existing fixtures stay cheap."""
+        monkeypatch.setenv("REPO_WIKI_COMPACT_LLM_PROMPT", "1")
+        monkeypatch.delenv("REPO_WIKI_LLM_COMPOSER_MAX_TOKENS", raising=False)
+        composer = create_composer()
+        resolved = composer._resolve_request_max_tokens()
+        assert resolved <= 1400
 
     @pytest.mark.asyncio
     async def test_compose_page_success(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Treat empty LLM `message.content` as a retryable compose failure, and stop the compact-prompt `max_tokens` cap of 1400 from starving reasoning models.

FastAPI RealWorld eval (nsidnev/fastapi-realworld-example-app @ 029eb77, repo-wiki `9cadf85` / PR #40): generate 89/89, **0×529**, but **60/89** pages were “LLM composer did not return content”. PR #40 retried HTTP 5xx/429; it did **not** cover HTTP 200 with blank assistant `content`. MiniMax-M3 can return 200 with empty `content` (tokens spent on hidden reasoning). `_normalize_markdown_response` then substituted that sentence, and `chat_with_retry` only retried `RetryableError` (5xx/429).

This change:
- Classifies empty/whitespace assistant `content` as `RetryableError` (`ErrorCode.EMPTY_CONTENT`) inside `chat_with_retry`, so `PageComposer` retries instead of writing a PASS shell.
- After retries are exhausted, `compose_page` returns `rejected=True` (orchestration fallback / `quality_state=DEGRADED`), never `rejected=False` with only that placeholder sentence.
- Raises compact `max_tokens` for **real** providers: configured `llm.max_tokens`, or at least 4096, still ≤ provider max. Mock/tests keep the compact 1400 cap.

Do not merge.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (typos, docs, etc.)
- [ ] Refactoring (no functional changes)
- [x] Tests (adding or updating tests)

## Related Issue
Follow-up to #40 (529/429 retry). Empty HTTP 200 path was still unhandled.

## Testing Performed
- [x] Ran tests locally: `pytest tests/test_llm_compose_retry.py tests/test_llm_page_composer.py tests/test_llm_retry_cache.py tests/test_llm_provider_contract.py`
- [x] Ran linting: `ruff format --check .` and `mypy repo_wiki --ignore-missing-imports`

TDD coverage:
1. Empty content twice, then markdown → success, 3 provider calls.
2. Always-empty content → `rejected=True` after retries; not a PASS shell.
3. Non-empty content is not retried (one call).
4. Compact max_tokens: real-looking `LlmConfig(max_tokens=8192)` is not clamped to 1400; mock keeps ≤1400.

## Checklist
- [x] My code follows the project's code style
- [x] I have performed self-review
- [x] I have commented complex code areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] Did not clone FastAPI/Flask, loosen verifier thresholds, or commit secrets
- [x] Did not re-break the engine↔scanner import cycle

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff32d245-3731-4d49-abe7-0cac68f11e3d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff32d245-3731-4d49-abe7-0cac68f11e3d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

