### PR TITLE
fix: join FastAPI router prefixes and don't empty-state real APIs

### DIFF
--- a/repo_wiki/orchestration/service.py
+++ b/repo_wiki/orchestration/service.py
@@ -1785,19 +1785,26 @@ class RepoWikiService:
         if not isinstance(raw_endpoints, list):
             return []
 
-        required_paths = set(
-            getattr(getattr(page, "source_requirements", None), "endpoints", []) or []
-        )
+        required_keys = {
+            str(item).upper().strip()
+            for item in getattr(getattr(page, "source_requirements", None), "endpoints", []) or []
+        }
         normalized: list[dict[str, Any]] = []
         for endpoint in raw_endpoints:
             if not isinstance(endpoint, dict):
                 continue
             method = str(endpoint.get("method") or "").upper().strip()
-            path = str(endpoint.get("path") or "").strip()
-            if not method or not path:
+            path = str(endpoint.get("path") or "").strip() or "/"
+            if not method:
                 continue
-            if required_paths and path not in required_paths:
-                continue
+            if required_keys:
+                endpoint_keys = {
+                    path.upper(),
+                    f"{method} {path}".upper(),
+                    f"{method} {str(endpoint.get('path') or '').strip()}".upper(),
+                }
+                if endpoint_keys.isdisjoint(required_keys):
+                    continue
             normalized.append(endpoint)
         return normalized[:25]
 

--- a/repo_wiki/scanner/fastapi_routes.py
+++ b/repo_wiki/scanner/fastapi_routes.py
@@ -1,0 +1,335 @@
+"""Extract FastAPI/APIRouter HTTP routes and join include_router prefixes."""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+_HTTP_METHODS = frozenset({"get", "post", "put", "patch", "delete", "options", "head"})
+_ROUTER_CTORS = frozenset({"APIRouter", "FastAPI"})
+
+
+@dataclass(frozen=True)
+class FastAPIEndpoint:
+    method: str
+    path: str
+    handler: str
+    file_path: str
+    lineno: int
+
+
+@dataclass
+class _RouterDef:
+    file_path: str
+    var_name: str
+    constructor_prefix: str = ""
+    is_app: bool = False
+    routes: list[tuple[str, str, str, int]] = field(default_factory=list)
+    mounts: list[tuple[str, str]] = field(default_factory=list)
+
+
+def join_http_paths(*parts: str) -> str:
+    """Join mount prefixes and a handler path into a single HTTP path."""
+    segments: list[str] = []
+    for part in parts:
+        text = str(part).strip()
+        if not text or text == "/":
+            continue
+        segments.extend(segment for segment in text.split("/") if segment)
+    return "/" + "/".join(segments) if segments else "/"
+
+
+def extract_fastapi_endpoints(files: Sequence[tuple[str, str]]) -> list[FastAPIEndpoint]:
+    """Return product HTTP routes with ``include_router`` prefixes joined.
+
+    ``files`` is a sequence of ``(relative_path, source_text)`` pairs. Prefixes
+    are joined at scan time so inventory paths match the mounted FastAPI app.
+    """
+    routers: dict[tuple[str, str], _RouterDef] = {}
+    imports_by_file: dict[str, dict[str, str]] = {}
+    aliases_by_file: dict[str, dict[str, tuple[str, str]]] = {}
+    file_set = {path for path, _text in files}
+
+    for path, text in files:
+        parsed = _parse_file(path, text)
+        if parsed is None:
+            continue
+        imports_by_file[path] = parsed[1]
+        aliases_by_file[path] = parsed[2]
+        for router in parsed[0]:
+            routers[(router.file_path, router.var_name)] = router
+
+    mounted: set[tuple[str, str]] = set()
+    endpoints: list[FastAPIEndpoint] = []
+    seen_walks: set[tuple[tuple[str, str], str]] = set()
+
+    def resolve_child(parent_file: str, child_ref: str) -> tuple[str, str] | None:
+        return _resolve_router_ref(
+            parent_file,
+            child_ref,
+            routers,
+            imports_by_file.get(parent_file, {}),
+            aliases_by_file.get(parent_file, {}),
+            file_set,
+        )
+
+    def walk(node_id: tuple[str, str], prefix: str) -> None:
+        walk_key = (node_id, prefix)
+        if walk_key in seen_walks:
+            return
+        seen_walks.add(walk_key)
+        router = routers.get(node_id)
+        if router is None:
+            return
+        mounted.add(node_id)
+        local_prefix = join_http_paths(prefix, router.constructor_prefix)
+        for method, path, handler, lineno in router.routes:
+            endpoints.append(
+                FastAPIEndpoint(
+                    method=method,
+                    path=join_http_paths(local_prefix, path),
+                    handler=handler,
+                    file_path=router.file_path,
+                    lineno=lineno,
+                )
+            )
+        for child_ref, mount_prefix in router.mounts:
+            child = resolve_child(router.file_path, child_ref)
+            if child is None:
+                continue
+            walk(child, join_http_paths(local_prefix, mount_prefix))
+
+    for node_id, router in routers.items():
+        if router.is_app:
+            walk(node_id, "")
+
+    for node_id, router in routers.items():
+        if node_id in mounted or router.is_app:
+            continue
+        local_prefix = router.constructor_prefix
+        for method, path, handler, lineno in router.routes:
+            endpoints.append(
+                FastAPIEndpoint(
+                    method=method,
+                    path=join_http_paths(local_prefix, path),
+                    handler=handler,
+                    file_path=router.file_path,
+                    lineno=lineno,
+                )
+            )
+
+    dedup: dict[tuple[str, str, str, str], FastAPIEndpoint] = {}
+    for endpoint in endpoints:
+        key = (endpoint.method, endpoint.path, endpoint.handler, endpoint.file_path)
+        dedup[key] = endpoint
+    return list(dedup.values())
+
+
+def _parse_file(
+    path: str, text: str
+) -> tuple[list[_RouterDef], dict[str, str], dict[str, tuple[str, str]]] | None:
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return None
+
+    routers: dict[str, _RouterDef] = {}
+    imported_modules: dict[str, str] = {}
+    imported_symbols: dict[str, tuple[str, str]] = {}
+
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                local = alias.asname or alias.name.split(".")[-1]
+                imported_modules[local] = alias.name
+        elif isinstance(node, ast.ImportFrom):
+            module = _absolute_module(path, node.module, node.level)
+            for alias in node.names:
+                local = alias.asname or alias.name
+                if module:
+                    imported_modules[local] = f"{module}.{alias.name}"
+                    imported_symbols[local] = (module, alias.name)
+                else:
+                    imported_modules[local] = alias.name
+                    imported_symbols[local] = (alias.name, alias.name)
+        elif isinstance(node, ast.Assign):
+            _maybe_bind_router(node.targets, node.value, path, routers)
+        elif isinstance(node, ast.AnnAssign) and node.value is not None and node.target is not None:
+            _maybe_bind_router([node.target], node.value, path, routers)
+
+    for walked in ast.walk(tree):
+        if isinstance(walked, ast.Call) and _is_include_router(walked):
+            parent_var = (
+                _name_of(walked.func.value) if isinstance(walked.func, ast.Attribute) else None
+            )
+            if parent_var is None:
+                continue
+            if parent_var not in routers:
+                routers[parent_var] = _RouterDef(file_path=path, var_name=parent_var)
+            child_ref = _expr_ref(walked.args[0]) if walked.args else None
+            if not child_ref:
+                continue
+            routers[parent_var].mounts.append((child_ref, _keyword_str(walked, "prefix") or ""))
+        elif isinstance(walked, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for decorator in walked.decorator_list:
+                parsed = _decorator_route(decorator)
+                if parsed is None:
+                    continue
+                router_var, method, route_path = parsed
+                if router_var not in routers:
+                    continue
+                routers[router_var].routes.append((method, route_path, walked.name, walked.lineno))
+
+    return list(routers.values()), imported_modules, imported_symbols
+
+
+def _maybe_bind_router(
+    targets: list[ast.expr], value: ast.AST, path: str, routers: dict[str, _RouterDef]
+) -> None:
+    ctor = _call_ctor_name(value)
+    if ctor not in _ROUTER_CTORS or not isinstance(value, ast.Call):
+        return
+    prefix = _keyword_str(value, "prefix") or ""
+    for target in targets:
+        if not isinstance(target, ast.Name):
+            continue
+        routers[target.id] = _RouterDef(
+            file_path=path,
+            var_name=target.id,
+            constructor_prefix=prefix,
+            is_app=ctor == "FastAPI",
+        )
+
+
+def _decorator_route(decorator: ast.AST) -> tuple[str, str, str] | None:
+    if not isinstance(decorator, ast.Call) or not isinstance(decorator.func, ast.Attribute):
+        return None
+    method = decorator.func.attr.lower()
+    if method not in _HTTP_METHODS:
+        return None
+    router_var = _name_of(decorator.func.value)
+    if router_var is None:
+        return None
+    path = ""
+    if decorator.args:
+        extracted = _const_str(decorator.args[0])
+        if extracted is not None:
+            path = extracted
+    for keyword in decorator.keywords:
+        if keyword.arg in {"path", "url"}:
+            extracted = _const_str(keyword.value)
+            if extracted is not None:
+                path = extracted
+    return router_var, method.upper(), path
+
+
+def _is_include_router(node: ast.Call) -> bool:
+    return isinstance(node.func, ast.Attribute) and node.func.attr == "include_router"
+
+
+def _resolve_router_ref(
+    parent_file: str,
+    child_ref: str,
+    routers: dict[tuple[str, str], _RouterDef],
+    imported_modules: dict[str, str],
+    imported_symbols: dict[str, tuple[str, str]],
+    file_set: set[str],
+) -> tuple[str, str] | None:
+    if "." not in child_ref:
+        local_key = (parent_file, child_ref)
+        if local_key in routers:
+            return local_key
+        if child_ref in imported_symbols:
+            module, orig = imported_symbols[child_ref]
+            return _find_router(module, orig, routers, file_set)
+        return None
+
+    module_local, attr = child_ref.split(".", 1)
+    module_candidates: list[str] = []
+    if module_local in imported_modules:
+        module_candidates.append(imported_modules[module_local])
+    if module_local in imported_symbols:
+        module, orig = imported_symbols[module_local]
+        module_candidates.append(f"{module}.{orig}")
+        module_candidates.append(module)
+    for module in module_candidates:
+        found = _find_router(module, attr, routers, file_set)
+        if found is not None:
+            return found
+    return None
+
+
+def _find_router(
+    module: str,
+    var_name: str,
+    routers: dict[tuple[str, str], _RouterDef],
+    file_set: set[str],
+) -> tuple[str, str] | None:
+    for candidate in _module_file_candidates(module):
+        if candidate in file_set and (candidate, var_name) in routers:
+            return candidate, var_name
+    stem = module.rsplit(".", 1)[-1]
+    matches = [
+        key
+        for key in routers
+        if key[1] == var_name and key[0].replace("\\", "/").endswith(f"/{stem}.py")
+    ]
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def _module_file_candidates(module: str) -> list[str]:
+    path = module.replace(".", "/")
+    return [f"{path}.py", f"{path}/__init__.py"]
+
+
+def _absolute_module(file_path: str, module: str | None, level: int) -> str:
+    if level <= 0:
+        return module or ""
+    parts = list(file_path.replace("\\", "/").removesuffix(".py").split("/"))
+    if parts:
+        parts = parts[:-1]
+    if level > 1:
+        parts = parts[: -(level - 1)] if len(parts) >= (level - 1) else []
+    extra = module.split(".") if module else []
+    return ".".join([*parts, *extra])
+
+
+def _call_ctor_name(node: ast.AST) -> str | None:
+    if not isinstance(node, ast.Call):
+        return None
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _keyword_str(call: ast.Call, name: str) -> str | None:
+    for keyword in call.keywords:
+        if keyword.arg == name:
+            return _const_str(keyword.value)
+    return None
+
+
+def _const_str(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _name_of(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    return None
+
+
+def _expr_ref(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+        return f"{node.value.id}.{node.attr}"
+    return None

--- a/repo_wiki/scanner/multi_runtime_scanner_v3.py
+++ b/repo_wiki/scanner/multi_runtime_scanner_v3.py
@@ -21,6 +21,7 @@ from typing import Any
 from repo_wiki.core.config import RepoWikiConfig
 from repo_wiki.orchestration.release_meta_schema import SCHEMA_VERSION_SOURCE_INVENTORY
 from repo_wiki.scanner.artifacts import is_product_source_path
+from repo_wiki.scanner.fastapi_routes import extract_fastapi_endpoints
 from repo_wiki.scanner.repository_scanner import RepositoryScanner
 
 # ---------------------------------------------------------------------------
@@ -162,20 +163,33 @@ def _scan_python(text: str, rel: str, record: FileScanRecord) -> None:
         record.services.append({"kind": "python_fastapi_app", "evidence_path": rel})
     if re.search(r"\bFlask\s*\(", text):
         record.services.append({"kind": "python_flask_app", "evidence_path": rel})
-    for meth, path_lit, handler in re.findall(
-        r"@(?:router|app|bp)\.(get|post|put|patch|delete)\(\s*[\"']([^\"']+)[\"'][^)]*\)\s*(?:async\s+)?def\s+(\w+)",
-        text,
-        re.IGNORECASE,
-    ):
-        record.api_surfaces.append(
-            {
-                "runtime": "python",
-                "method": meth.upper(),
-                "path": path_lit,
-                "handler": handler,
-                "evidence_path": rel,
-            }
-        )
+    fastapi_endpoints = extract_fastapi_endpoints([(rel, text)])
+    if fastapi_endpoints:
+        for endpoint in fastapi_endpoints:
+            record.api_surfaces.append(
+                {
+                    "runtime": "python",
+                    "method": endpoint.method,
+                    "path": endpoint.path,
+                    "handler": endpoint.handler,
+                    "evidence_path": rel,
+                }
+            )
+    else:
+        for meth, path_lit, handler in re.findall(
+            r"@(?:router|app|bp)\.(get|post|put|patch|delete)\(\s*[\"']([^\"']*)[\"'][^)]*\)\s*(?:async\s+)?def\s+(\w+)",
+            text,
+            re.IGNORECASE,
+        ):
+            record.api_surfaces.append(
+                {
+                    "runtime": "python",
+                    "method": meth.upper(),
+                    "path": path_lit,
+                    "handler": handler,
+                    "evidence_path": rel,
+                }
+            )
     for base in re.findall(
         r"class\s+(\w+)\s*\(\s*(?:BaseModel|SQLModel|DeclarativeBase|db\.Model)",
         text,

--- a/repo_wiki/scanner/repository_scanner.py
+++ b/repo_wiki/scanner/repository_scanner.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from fnmatch import fnmatch
 from pathlib import Path
+from typing import Literal
 
 from pathspec import PathSpec
 
@@ -27,11 +28,23 @@ from repo_wiki.core.security import (
     should_scan,
 )
 from repo_wiki.scanner.artifacts import is_product_source_path, path_role_for
+from repo_wiki.scanner.fastapi_routes import extract_fastapi_endpoints
 
 _CODE_SUFFIXES = {".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".java", ".kt"}
 _MODEL_FILE_HINTS = ("model", "schema", "entity", "dto", "migration", "alembic")
 _MODULE_ROOT_HINTS = {"src", "app", "apps", "services", "modules", "internal", "cmd"}
 _HTTP_METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD")
+_HTTP_METHOD_LITERALS: dict[
+    str, Literal["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
+] = {
+    "GET": "GET",
+    "POST": "POST",
+    "PUT": "PUT",
+    "PATCH": "PATCH",
+    "DELETE": "DELETE",
+    "OPTIONS": "OPTIONS",
+    "HEAD": "HEAD",
+}
 
 # Domain classification signals
 _DOMAIN_SIGNALS: dict[str, tuple[frozenset[str], float]] = {
@@ -506,6 +519,30 @@ class RepositoryScanner:
         self, files: list[ScannedFile], modules: dict[str, Module]
     ) -> list[Endpoint]:
         endpoints: list[Endpoint] = []
+        python_files = [
+            (file.path.as_posix(), file.text)
+            for file in files
+            if file.path.suffix.lower() == ".py" and is_product_source_path(file.path.as_posix())
+        ]
+        fastapi_endpoints = extract_fastapi_endpoints(python_files)
+        fastapi_files = {item.file_path for item in fastapi_endpoints}
+        for item in fastapi_endpoints:
+            method = _HTTP_METHOD_LITERALS.get(item.method.upper())
+            if method is None:
+                continue
+            module_path = self._choose_module_path(Path(item.file_path))
+            module_name = modules[module_path].name if module_path in modules else module_path
+            endpoints.append(
+                Endpoint(
+                    method=method,
+                    path=item.path,
+                    module=module_name,
+                    handler=item.handler,
+                    file_path=item.file_path,
+                    line_number=item.lineno,
+                )
+            )
+
         for file in files:
             suffix = file.path.suffix.lower()
             if suffix not in _CODE_SUFFIXES:
@@ -515,21 +552,25 @@ class RepositoryScanner:
             module_path = self._choose_module_path(file.path)
             module_name = modules[module_path].name
             text = file.text
+            skip_fastapi_decorators = file.path.as_posix() in fastapi_files or bool(
+                re.search(r"\b(?:APIRouter|FastAPI)\s*\(", text)
+            )
 
-            for method, path_expr, handler in re.findall(
-                r"\b(?:router|app|server|r)\.(get|post|put|patch|delete|options|head)\(\s*[\"']([^\"']+)[\"']\s*,\s*([A-Za-z_][A-Za-z0-9_]*)",
-                text,
-                re.IGNORECASE,
-            ):
-                endpoints.append(
-                    Endpoint(
-                        method=method.upper(),
-                        path=path_expr,
-                        module=module_name,
-                        handler=handler,
-                        file_path=file.path.as_posix(),
+            if not skip_fastapi_decorators:
+                for method, path_expr, handler in re.findall(
+                    r"\b(?:router|app|server|r)\.(get|post|put|patch|delete|options|head)\(\s*[\"']([^\"']+)[\"']\s*,\s*([A-Za-z_][A-Za-z0-9_]*)",
+                    text,
+                    re.IGNORECASE,
+                ):
+                    endpoints.append(
+                        Endpoint(
+                            method=method.upper(),
+                            path=path_expr,
+                            module=module_name,
+                            handler=handler,
+                            file_path=file.path.as_posix(),
+                        )
                     )
-                )
 
             for decorator, path_expr in re.findall(
                 r"@(Get|Post|Put|Patch|Delete|Options|Head)\(\s*[\"']?([^\"')]+)[\"']?\)", text
@@ -544,20 +585,21 @@ class RepositoryScanner:
                     )
                 )
 
-            for method, path_expr in re.findall(
-                r"@(?:app|router|bp)\.(get|post|put|patch|delete|options|head)\(\s*[\"']([^\"']+)[\"']",
-                text,
-                re.IGNORECASE,
-            ):
-                endpoints.append(
-                    Endpoint(
-                        method=method.upper(),
-                        path=path_expr,
-                        module=module_name,
-                        handler=self._guess_handler(text),
-                        file_path=file.path.as_posix(),
+            if not skip_fastapi_decorators:
+                for method, path_expr in re.findall(
+                    r"@(?:app|router|bp)\.(get|post|put|patch|delete|options|head)\(\s*[\"']([^\"']+)[\"']",
+                    text,
+                    re.IGNORECASE,
+                ):
+                    endpoints.append(
+                        Endpoint(
+                            method=method.upper(),
+                            path=path_expr,
+                            module=module_name,
+                            handler=self._guess_handler(text),
+                            file_path=file.path.as_posix(),
+                        )
                     )
-                )
 
             for path_expr, handler in re.findall(
                 r"http\.HandleFunc\(\s*[\"']([^\"']+)[\"']\s*,\s*([A-Za-z_][A-Za-z0-9_]*)", text
@@ -572,19 +614,20 @@ class RepositoryScanner:
                     )
                 )
 
-            for method, path_expr, handler in re.findall(
-                r"\b(?:r|router|app)\.(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\(\s*[\"']([^\"']+)[\"']\s*,\s*([A-Za-z_][A-Za-z0-9_]*)",
-                text,
-            ):
-                endpoints.append(
-                    Endpoint(
-                        method=method.upper(),
-                        path=path_expr,
-                        module=module_name,
-                        handler=handler,
-                        file_path=file.path.as_posix(),
+            if not skip_fastapi_decorators:
+                for method, path_expr, handler in re.findall(
+                    r"\b(?:r|router|app)\.(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\(\s*[\"']([^\"']+)[\"']\s*,\s*([A-Za-z_][A-Za-z0-9_]*)",
+                    text,
+                ):
+                    endpoints.append(
+                        Endpoint(
+                            method=method.upper(),
+                            path=path_expr,
+                            module=module_name,
+                            handler=handler,
+                            file_path=file.path.as_posix(),
+                        )
                     )
-                )
 
             # Flask-style @app.route("/path", methods=["GET"])
             for path_expr, methods in re.findall(

--- a/tests/test_api_aggregator.py
+++ b/tests/test_api_aggregator.py
@@ -810,3 +810,78 @@ class TestEmptyEndpointState:
         assert "`/health`" in table
         assert "[模块文档](modules/api.md)" in table
         assert "[测试模块](modules/tests.md)" in table
+
+    def test_relative_product_router_paths_do_not_use_empty_state(self, tmp_path: Path):
+        """Relative FastAPI router paths are still a product HTTP inventory."""
+        endpoints = [
+            {
+                "method": "POST",
+                "path": "/login",
+                "module": "authentication",
+                "handler": "login",
+                "file_path": "app/api/routes/authentication.py",
+            },
+            {
+                "method": "GET",
+                "path": "/feed",
+                "module": "articles",
+                "handler": "get_articles_feed",
+                "file_path": "app/api/routes/articles_common.py",
+            },
+            {
+                "method": "GET",
+                "path": "/{slug}",
+                "module": "articles",
+                "handler": "get_article",
+                "file_path": "app/api/routes/articles.py",
+            },
+        ]
+        modules = [
+            {
+                "name": "authentication",
+                "domain": "api-gateway",
+                "service_family": "python-backend",
+                "runtime_role": "api-server",
+            },
+            {
+                "name": "articles",
+                "domain": "api-gateway",
+                "service_family": "python-backend",
+                "runtime_role": "api-server",
+            },
+        ]
+
+        aggregator = APIAggregator(endpoints=endpoints, modules=modules)
+        table = aggregator.build_api_groups_table()
+        detail = aggregator.build_api_groups_detail()
+
+        assert table != APIAggregator.NO_HTTP_API_MESSAGE
+        assert "UNRESOLVED_API_ENDPOINTS" not in table
+        assert "UNRESOLVED_API_ENDPOINTS" not in detail
+        assert APIAggregator.NO_HTTP_API_MESSAGE not in table
+        assert APIAggregator.NO_HTTP_API_MESSAGE not in detail
+
+        engine = GenerationEngine(tmp_path, template_root=tmp_path)
+        context = engine._build_core_context(
+            {
+                "repo_map": {"repository": {"name": "conduit"}, "commands": {}},
+                "module_index": {"modules": modules},
+                "api_index": {"endpoints": endpoints},
+                "data_models": {"models": []},
+                "graph": {"modules": {}},
+            }
+        )
+        rendered = "\n".join(
+            str(context.get(key, ""))
+            for key in (
+                "endpoint_index_table",
+                "api_groups_table",
+                "api_groups_detail",
+                "authentication_patterns",
+                "error_status_behavior",
+            )
+        )
+        assert APIAggregator.NO_HTTP_API_MESSAGE not in rendered
+        assert "UNRESOLVED_API_ENDPOINTS" not in rendered
+        assert "`/login`" in context["endpoint_index_table"]
+        assert "`/{slug}`" in context["endpoint_index_table"]

--- a/tests/test_fastapi_router_inventory.py
+++ b/tests/test_fastapi_router_inventory.py
@@ -1,0 +1,186 @@
+"""FastAPI APIRouter prefixes and decorator isolation for product HTTP inventory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from repo_wiki.core.config import RepoWikiConfig
+from repo_wiki.scanner.repository_scanner import RepositoryScanner
+
+
+def _scan(root: Path):
+    cfg = RepoWikiConfig.model_validate({"project": {"root": str(root)}})
+    return RepositoryScanner(cfg).scan()
+
+
+def test_include_router_prefix_is_joined_into_product_path(tmp_path: Path) -> None:
+    (tmp_path / "app").mkdir()
+    (tmp_path / "app" / "main.py").write_text(
+        """
+from fastapi import APIRouter, FastAPI
+
+router = APIRouter()
+
+
+@router.post("/login")
+async def login():
+    return {"ok": True}
+
+
+api = APIRouter()
+api.include_router(router, prefix="/users")
+
+app = FastAPI()
+app.include_router(api)
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+
+    snapshot = _scan(tmp_path)
+    pairs = {(endpoint.method, endpoint.path) for endpoint in snapshot.endpoints}
+
+    assert ("POST", "/users/login") in pairs
+    assert ("POST", "/login") not in pairs
+
+
+def test_app_include_router_prefix_is_joined(tmp_path: Path) -> None:
+    (tmp_path / "app").mkdir()
+    (tmp_path / "app" / "main.py").write_text(
+        """
+from fastapi import APIRouter, FastAPI
+
+router = APIRouter()
+
+
+@router.post("/login")
+async def login():
+    return {"ok": True}
+
+
+api = APIRouter()
+api.include_router(router, prefix="/users")
+
+app = FastAPI()
+app.include_router(api, prefix="/api")
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+
+    snapshot = _scan(tmp_path)
+    pairs = {(endpoint.method, endpoint.path) for endpoint in snapshot.endpoints}
+
+    assert ("POST", "/api/users/login") in pairs
+    assert ("POST", "/login") not in pairs
+    assert ("POST", "/users/login") not in pairs
+
+
+def test_cross_file_include_router_prefix_is_joined(tmp_path: Path) -> None:
+    routes = tmp_path / "app" / "api" / "routes"
+    routes.mkdir(parents=True)
+    (routes / "authentication.py").write_text(
+        """
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.post("/login")
+async def login():
+    return {"token": "x"}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (routes / "api.py").write_text(
+        """
+from fastapi import APIRouter
+
+from app.api.routes import authentication
+
+router = APIRouter()
+router.include_router(authentication.router, prefix="/users")
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "app" / "main.py").write_text(
+        """
+from fastapi import FastAPI
+
+from app.api.routes.api import router as api_router
+
+app = FastAPI()
+app.include_router(api_router)
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+
+    snapshot = _scan(tmp_path)
+    pairs = {(endpoint.method, endpoint.path) for endpoint in snapshot.endpoints}
+
+    assert ("POST", "/users/login") in pairs
+    assert ("POST", "/login") not in pairs
+
+
+def test_decorator_method_and_path_stay_on_their_handler(tmp_path: Path) -> None:
+    (tmp_path / "app").mkdir()
+    (tmp_path / "app" / "articles.py").write_text(
+        """
+from fastapi import APIRouter, FastAPI
+
+router = APIRouter()
+
+
+@router.get("")
+def list_articles():
+    return []
+
+
+@router.get("/{slug}")
+def get_article():
+    return {}
+
+
+@router.delete("/{slug}")
+def delete_article():
+    return None
+
+
+app = FastAPI()
+app.include_router(router, prefix="/articles")
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+
+    snapshot = _scan(tmp_path)
+    by_handler = {}
+    for endpoint in snapshot.endpoints:
+        by_handler.setdefault(endpoint.handler, []).append(endpoint)
+
+    list_eps = by_handler["list_articles"]
+    assert list_eps
+    assert all(endpoint.method == "GET" for endpoint in list_eps)
+    assert all(endpoint.method != "DELETE" for endpoint in list_eps)
+    assert all(
+        endpoint.path in {"", "/", "/articles"} or endpoint.path.endswith("/articles")
+        for endpoint in list_eps
+    )
+    assert not any("/{slug}" in endpoint.path for endpoint in list_eps)
+
+    get_eps = by_handler["get_article"]
+    assert get_eps
+    assert all(endpoint.method == "GET" for endpoint in get_eps)
+    assert any(endpoint.path.endswith("/{slug}") for endpoint in get_eps)
+
+    delete_eps = by_handler["delete_article"]
+    assert delete_eps
+    assert all(endpoint.method == "DELETE" for endpoint in delete_eps)
+    assert any(endpoint.path.endswith("/{slug}") for endpoint in delete_eps)

--- a/tests/test_init_stub_identity.py
+++ b/tests/test_init_stub_identity.py
@@ -144,3 +144,48 @@ def test_rendered_init_overview_is_marked_as_placeholder(tmp_path: Path) -> None
     assert "repo-wiki-init-stub" in content
     for phrase in _INVENTED_IDENTITY_PHRASES:
         assert phrase not in content
+
+
+def test_init_stub_section_docs_are_not_product_identity_claims(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "lib.py").write_text("def ping():\n    return True\n", encoding="utf-8")
+    (tmp_path / "docs" / "sections" / "api").mkdir(parents=True)
+    (tmp_path / "docs" / "sections" / "services").mkdir(parents=True)
+    stub = """# API Reference and Contracts
+
+<!-- repo-wiki-init-stub -->
+
+本节涵盖 core-platform 等 3 个模块的内容。
+系统提供 api-gateway 与核心平台基础设施。
+知识管理和文档生成平台面向开发者。
+"""
+    (tmp_path / "docs" / "sections" / "api" / "index.md").write_text(stub, encoding="utf-8")
+    (tmp_path / "docs" / "sections" / "services" / "index.md").write_text(
+        "# Core Services\n\n<!-- repo-wiki-init-stub -->\n\ncore-platform api-gateway\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "# Conduit\n\nRealWorld FastAPI example app for users and articles.\n",
+        encoding="utf-8",
+    )
+
+    inventory = scan_repository_docs_inventory(
+        tmp_path, _source_inventory(), incremental=False, persist_cache=False
+    )
+    section_docs = [
+        doc
+        for doc in inventory["documents"]
+        if str(doc.get("path", "")).startswith("docs/sections/")
+    ]
+    assert section_docs
+    for doc in section_docs:
+        claims = " ".join(doc.get("conflicting_claims") or [])
+        stale = " ".join(doc.get("stale_references") or [])
+        assert doc["authority_level"] not in {"source_backed"}
+        assert doc["authority_score"] < 0.5
+        assert "知识管理" not in claims
+        assert "api-gateway" not in claims
+        assert "core-platform" not in claims
+        assert "知识管理" not in stale
+        assert "api-gateway" not in stale
+        assert "core-platform" not in stale

--- a/tests/test_qoder_page_contract_truthfulness.py
+++ b/tests/test_qoder_page_contract_truthfulness.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from repo_wiki.core.config import RepoWikiConfig
 from repo_wiki.generator.composer import ComposerContext
 from repo_wiki.orchestration.service import RepoWikiService
-from repo_wiki.planner.schema import WikiPagePlan, WikiTaxonomyCategory
+from repo_wiki.planner.schema import SourceRequirement, WikiPagePlan, WikiTaxonomyCategory
 
 
 def _service(tmp_path):
@@ -99,3 +99,62 @@ def test_qoder_page_contract_preserves_evidence_backed_endpoint_data(tmp_path):
     assert "error_codes=[404]" in rendered
     assert "/resources" not in rendered
     assert "Bearer token" not in rendered
+
+
+def test_qoder_api_page_does_not_empty_state_when_product_endpoints_exist(tmp_path):
+    """Planner stores 'METHOD path'; empty-state must not fire if those endpoints exist."""
+    service = _service(tmp_path)
+    page = WikiPagePlan(
+        page_id="api-reference",
+        title="API参考",
+        category=WikiTaxonomyCategory.API_REFERENCE,
+        output_path="API参考/API参考.md",
+        source_requirements=SourceRequirement(
+            endpoints=["POST /login", "GET /feed", "GET /{slug}"],
+        ),
+    )
+    context = ComposerContext(
+        repository_name="conduit",
+        primary_language="python",
+        framework="fastapi",
+        repository_root=str(tmp_path),
+        endpoints=[
+            {
+                "method": "POST",
+                "path": "/login",
+                "module": "authentication",
+                "handler": "login",
+                "file_path": "app/api/routes/authentication.py",
+                "line_number": 12,
+            },
+            {
+                "method": "GET",
+                "path": "/feed",
+                "module": "articles",
+                "handler": "articles_feed",
+                "file_path": "app/api/routes/articles_common.py",
+                "line_number": 8,
+            },
+            {
+                "method": "GET",
+                "path": "/{slug}",
+                "module": "articles",
+                "handler": "get_article",
+                "file_path": "app/api/routes/articles.py",
+                "line_number": 40,
+            },
+        ],
+    )
+
+    rendered = service._enforce_qoder_page_contract(
+        page=page,
+        markdown="# API参考\n\n## 简介\n\n短说明。",
+        binding=None,
+        add_mermaid=False,
+        composition_context=context,
+    )
+
+    assert "UNRESOLVED_API_ENDPOINTS" not in rendered
+    assert "POST /login" in rendered
+    assert "GET /feed" in rendered
+    assert "GET /{slug}" in rendered


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fix FastAPI product-API scanning and API-contracts empty-state, based on a real eval of `nsidnev/fastapi-realworld-example-app` @ `029eb77` (do not clone that repo into CI).

`repo-wiki index` reported **endpoints=11** while RealWorld has login/register, current user, articles CRUD + feed, comments, profiles, and tags. `ai/source-of-truth/api-index.yaml` showed:

- `POST /login` from `authentication.py` — missing `include_router(..., prefix="/users")` so it was not `/users/login`
- `GET /feed` from `articles_common.py` — missing prefix `/articles`
- `list_articles` recorded as **DELETE `/{slug}`** and **GET `/{slug}`** (neighboring decorators leaked onto the wrong handler)
- Comments `/{comment_id}` without `/articles/{slug}/comments`

Wiki `API参考/API参考.md` still emitted `UNRESOLVED_API_ENDPOINTS` despite those 11 product endpoints existing (citations even pointed at `authentication.py` login and `articles_common.py` feed). Empty-state must only apply when the **product** inventory is truly empty.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (adding or updating tests)

## Related Issue
Eval of nsidnev/fastapi-realworld-example-app @ 029eb77. repo-wiki main already includes PR #39 (path roles) and #40 (529 retry).

## What changed
- **Scan-time** FastAPI AST extraction (`repo_wiki/scanner/fastapi_routes.py`) binds each `@router.get/post/put/delete` to the **next** function and walks `include_router(..., prefix=)` (including cross-file mounts) so product inventory stores **mounted** paths.
- Qoder API page contract matches planner `METHOD path` keys, so product endpoints no longer fall through to `UNRESOLVED_API_ENDPOINTS`.
- Relative router paths such as `/{slug}` still count as HTTP APIs for aggregator / `docs/04` groups tables.
- Regression: `docs/sections/**` files marked `<!-- repo-wiki-init-stub -->` still do not feed product identity claims (already covered by #39; test extended).

Verifier thresholds are unchanged. No secrets. Flask/FastAPI upstream repos are not cloned into CI.

## Testing Performed
- [x] Ran tests locally:
  - `pytest tests/test_fastapi_router_inventory.py tests/test_api_aggregator.py tests/test_docs_api_contracts_empty.py tests/test_path_role_product_inventory.py tests/test_qoder_page_contract_truthfulness.py tests/test_init_stub_identity.py tests/test_engine_import_cycle.py`
- [x] `ruff format --check .`
- [x] `mypy repo_wiki --ignore-missing-imports`

New/extended tests:
1. Prefix join: `POST /users/login` (and `/api/users/login` with app prefix); bare `/login` must not be the product path
2. Cross-file `include_router(authentication.router, prefix="/users")`
3. Method isolation: `list_articles` is GET, never DELETE; `get_article` GET; `delete_article` DELETE
4. Product endpoints (even relative `/{slug}`) must not render `UNRESOLVED_API_ENDPOINTS` / `NO_HTTP_API_MESSAGE`
5. Existing empty-state tests kept for truly empty product APIs
6. Init stubs under `docs/sections/**` are not product identity claims

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c214766-f619-44c7-bef1-f1b7b0d99844?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c214766-f619-44c7-bef1-f1b7b0d99844&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

