### PR TITLE
docs: FastAPI RealWorld round-2 wiki quality eval

### DIFF
--- a/docs/eval/2026-08-13-fastapi-realworld-round2-verify.json
+++ b/docs/eval/2026-08-13-fastapi-realworld-round2-verify.json
@@ -1,0 +1,42 @@
+{
+  "grade": "FAIL",
+  "profile": "qoder-like",
+  "exit_code": 1,
+  "status": "NOT_READY",
+  "fastapi_sha": "029eb7781c60d5f563ee8990a0cbfb79b244538c",
+  "repo_wiki_sha": "c2407979c6eb7d7a88cafc6ebd606a5952064684",
+  "model": "MiniMax-M3",
+  "summary": {
+    "total": 25,
+    "pass": 12,
+    "warn": 0,
+    "fail": 13,
+    "hard_gate_failures": 13,
+    "soft_gate_failures": 0
+  },
+  "hard_gate_codes": [
+    "QODER_MANIFEST_PATH_INVALID",
+    "QODER_PAGE_QUALITY_STATE_MISSING",
+    "QODER_UNRESOLVED_FACT_CONFLICT",
+    "QODER_REQUIRED_INVENTORY_MISSING",
+    "QODER_CITATION_INVALID",
+    "QODER_CITATION_FACT_COVERAGE_LOW",
+    "QODER_OWNER_COVERAGE_MISSING",
+    "QODER_CITATION_RELEVANCE_MISMATCH",
+    "QODER_API_MERMAID_MISSING",
+    "QODER_DATA_MODEL_ER_MERMAID_MISSING",
+    "QODER_PAGE_DUMP",
+    "QODER_PROSE_TOO_LOW",
+    "QODER_DIRTY_WORKTREE"
+  ],
+  "notes": {
+    "pages": 89,
+    "empty_llm_shells": 0,
+    "endpoints": 19,
+    "unresolved_in_wiki": 0,
+    "prefixed_users_login": false,
+    "llm_529": 0,
+    "fallback_page_count": 2,
+    "claim_coverage": "51.28%"
+  }
+}

--- a/docs/eval/2026-08-13-fastapi-realworld-round2.md
+++ b/docs/eval/2026-08-13-fastapi-realworld-round2.md
@@ -1,0 +1,34 @@
+# FastAPI RealWorld 对照 Wiki 第二轮评测
+
+**对照仓：** nsidnev/fastapi-realworld-example-app `029eb778`  
+**CLI：** repo-wiki `c2407979`（含 PR #42 空 content 重试与 #43 FastAPI 扫描）  
+**模型：** MiniMax-M3；timeout 180s；concurrency 2  
+**时间：** 2026-08-13 22:42–23:02 CST（compose ≈19m）  
+**verify JSON：** `docs/eval/2026-08-13-fastapi-realworld-round2-verify.json`
+
+第一轮评测见 `docs/eval/2026-08-13-fastapi-realworld-round1.md`。
+
+## 生成
+
+| 项 | r1 | r2 |
+|---|---|---|
+| generate | 89/89 | 89/89 |
+| 空壳 “LLM composer did not return content” | 60/89 | **0/89** |
+| 529 | 0 | 0 |
+| fallback / rejected | 0 | 2（Insufficient prose） |
+| endpoints | 11 | **19**（仍无 include_router 前缀） |
+| wiki 中 UNRESOLVED | 24 | **0** |
+
+## Verify
+
+13 HARD / 0 SOFT（r1 为 12/0，新加 `QODER_PROSE_TOO_LOW`）。claim coverage 43.5%→51.3%。API aggregation PASS 13/13。无效 citation 22→56（`file:` 前缀）。未放宽阈值。
+
+## Must-check
+
+- Overview **仍不是** Conduit；**没有**「知识管理平台」。
+- API参考 **无** UNRESOLVED，**未编造** `/health` `/webhook` `/items`。**仍无** `/users/login` `/articles` 完整前缀（只有 `POST /login` `GET /feed` `GET /`）。handler 错绑已修。
+- 数据模型有 User/Comment/Article DTO；ER 仍缺 User/Tag。
+
+## #43 残留
+
+本仓 `include_router` 形态：`get_application()` 内 `FastAPI()`；`application.include_router(api_router, prefix=settings.api_prefix)`（非字面量）；`router.include_router(authentication.router, prefix="/users")` 跨模块。#43 的字面量同文件夹具没覆盖到。

--- a/docs/eval/2026-08-13-fastapi-realworld-wrap.md
+++ b/docs/eval/2026-08-13-fastapi-realworld-wrap.md
@@ -1,10 +1,35 @@
 # FastAPI RealWorld wiki 质量对照 wrap
 
 **日期：** 2026-08-13 CST  
-**对照：** nsidnev/fastapi-realworld-example-app `029eb778` × MiniMax-M3 × repo-wiki `9cadf85`（PR #40）
+**对照：** nsidnev/fastapi-realworld-example-app `029eb778` × MiniMax-M3  
+**CLI：** r1 `9cadf85`（#40）→ r2 `c2407979`（#42 空 content 重试 + #43 FastAPI 扫描）
 
-- generate 成功：89 页，0 次 529，0 fallback。
-- 新主伤：60/89 空壳（HTTP 200 + 空 content，compact 1400）。
-- PR #39：概述不再自称知识管理平台；污染换成 AGENTS.md。
-- 04 没编造 /health，也没写出 /users/login、/articles 完整前缀。scanner 11 条相对 path 且 handler 错绑。
-- verify 12 HARD / 0 SOFT。不要松阈值。generator-fix 另开 PR。
+第一轮评测见 `docs/eval/2026-08-13-fastapi-realworld-round1.md`。
+
+## r1 vs r2
+
+| 项 | r1 | r2 |
+|---|---|---|
+| generate | 89/89 | 89/89 |
+| 空壳 “LLM composer did not return content” | 60/89 | **0/89** |
+| 529 | 0 | 0 |
+| fallback / rejected | 0 | 2（Insufficient prose） |
+| endpoints | 11 | **19**（仍无 include_router 前缀） |
+| wiki 中 UNRESOLVED | 24 | **0** |
+
+## 本回路已合并（#37–#43）
+
+- **#37**（`98aa8bd`）：packaged templates、长 citation 路径、LLM 页超时跟 YAML/300s cap。
+- **#38**：Flask round-2 评测文档。
+- **#39**：库仓 path roles、忽略 init stub、qoder meta 查找；概述不再自称知识管理平台。
+- **#40**（`9cadf85`）：HTTP 529/429 重试。FastAPI r1：89 页、0 次 529、**60/89 空壳**。
+- **#41**：FastAPI RealWorld round-1 评测文档。
+- **#42**：空 `message.content` 当 retryable；compact `max_tokens` 不再 1400 饿死推理模型。r2 空壳 **60→0**。
+- **#43**（`c2407979`）：FastAPI `include_router` 前缀拼接、按装饰器绑 handler、有产品 API 时禁止 04 UNRESOLVED。r2 endpoints 11→19，wiki UNRESOLVED 24→0。
+
+## 残留
+
+- **Prefix join 仍残留：** 对照仓是 `get_application()` 内 `FastAPI()`；`application.include_router(api_router, prefix=settings.api_prefix)`（非字面量）；`router.include_router(authentication.router, prefix="/users")` 跨模块。#43 字面量同文件夹具未覆盖。仍无 `/users/login`、`/articles` 完整前缀（只有 `POST /login` `GET /feed` `GET /`）。
+- Overview **仍不是** Conduit（未再出现「知识管理平台」）。
+- 数据模型有 User/Comment/Article DTO；ER 仍缺 User/Tag。
+- r2 verify：**13 HARD / 0 SOFT**（r1 为 12/0，新加 `QODER_PROSE_TOO_LOW`）。claim coverage 43.5%→51.3%。API aggregation PASS 13/13。无效 citation 22→56（`file:` 前缀）。2 页 fallback/rejected（Insufficient prose）。不要松阈值。generator-fix 另开 PR。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Add FastAPI RealWorld round-2 wiki quality eval artifacts under `docs/eval/`. This records MiniMax-M3 generate/verify against `nsidnev/fastapi-realworld-example-app` at `029eb778` using repo-wiki `c2407979` (PRs #42 empty-content retry and #43 FastAPI scan). No generator code, secrets, wiki dumps, or FastAPI submodule are included.

Do not merge from this agent.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update (typos, docs, etc.)
- [ ] Refactoring (no functional changes)
- [ ] Tests (adding or updating tests)

## Related Issue

Follow-up to round-1 eval `#41` and generator PRs `#42` / `#43`. Flask eval files are unchanged.

## Files

- `docs/eval/2026-08-13-fastapi-realworld-round2.md` — round-2 generate/verify, must-check, #43 residual
- `docs/eval/2026-08-13-fastapi-realworld-wrap.md` — r1 vs r2 table and #37–#43 residual list; one-line pointer to round-1
- `docs/eval/2026-08-13-fastapi-realworld-round2-verify.json` — redacted verify summary (`FAIL`, 13 HARD / 0 SOFT)

Round-1 FastAPI (`round1.md`, `round1-verify.json`) and Flask eval files are left alone.

## Findings (for reviewers)

- generate: 89/89 pages; empty LLM shells **60→0**; 0×529; 2 fallback/rejected (Insufficient prose)
- endpoints 11→19 (still no joined `include_router` prefixes); wiki UNRESOLVED 24→0
- verify: 13 HARD / 0 SOFT (new `QODER_PROSE_TOO_LOW`); claim coverage 43.5%→51.3%; API aggregation PASS 13/13
- Prefix join still residual (`settings.api_prefix` non-literal + cross-module `/users`). Do not loosen thresholds.

## Testing Performed
- [ ] Ran tests locally: `pytest`
- [ ] Ran linting: `ruff check .`

Docs-only; no generator or CLI changes. JSON parsed with `python3`.

## Checklist
- [x] My code follows the project's code style
- [x] I have performed self-review
- [ ] I have commented complex code areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f70cd687-2888-4a7e-8a95-9a7c2b6a08e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f70cd687-2888-4a7e-8a95-9a7c2b6a08e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

