### PR TITLE
fix: v3 FastAPI scan joins prefixes; resolve settings factory api_prefix

### DIFF
--- a/repo_wiki/scanner/fastapi_routes.py
+++ b/repo_wiki/scanner/fastapi_routes.py
@@ -31,6 +31,7 @@ class _FileFacts:
     class_str_attrs: dict[tuple[str, str], str] = field(default_factory=dict)
     instances: dict[str, str] = field(default_factory=dict)
     module_str_attrs: dict[str, str] = field(default_factory=dict)
+    factories: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -209,6 +210,12 @@ def _parse_file(
         elif isinstance(walked, ast.ClassDef):
             _collect_class_str_attrs(walked, facts)
 
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            returned = _factory_return_class(node)
+            if returned is not None:
+                facts.factories[node.name] = returned
+
     for walked in ast.walk(tree):
         if isinstance(walked, ast.Call) and _is_include_router(walked):
             parent_var = (
@@ -313,44 +320,167 @@ def _resolve_prefix_ref(
     if "." not in prefix_ref:
         return None
     owner, attr = prefix_ref.split(".", 1)
+    return _resolve_named_str_attr(
+        parent_file,
+        owner,
+        attr,
+        facts_by_file,
+        aliases_by_file,
+        file_set,
+        set(),
+    )
 
-    def lookup(file_path: str, name: str) -> str | None:
-        facts = facts_by_file.get(file_path)
-        if facts is None:
-            return None
-        if name in facts.instances:
-            class_name = facts.instances[name]
-            found = facts.class_str_attrs.get((class_name, attr))
-            if found is not None:
-                return found
-        found = facts.class_str_attrs.get((name, attr))
-        if found is not None:
-            return found
-        if name == attr:
-            return facts.module_str_attrs.get(attr)
+
+def _resolve_named_str_attr(
+    file_path: str,
+    owner: str,
+    attr: str,
+    facts_by_file: dict[str, _FileFacts],
+    aliases_by_file: dict[str, dict[str, tuple[str, str]]],
+    file_set: set[str],
+    seen: set[tuple[str, str]],
+) -> str | None:
+    key = (file_path, owner)
+    if key in seen:
+        return None
+    seen.add(key)
+    facts = facts_by_file.get(file_path)
+    if facts is None:
         return None
 
-    local = lookup(parent_file, owner)
-    if local is not None:
-        return local
+    found = facts.class_str_attrs.get((owner, attr))
+    if found is not None:
+        return found
+    if owner == attr:
+        module_val = facts.module_str_attrs.get(attr)
+        if module_val is not None:
+            return module_val
 
-    imported = aliases_by_file.get(parent_file, {}).get(owner)
+    if owner in facts.instances:
+        bound = _resolve_named_str_attr(
+            file_path,
+            facts.instances[owner],
+            attr,
+            facts_by_file,
+            aliases_by_file,
+            file_set,
+            seen,
+        )
+        if bound is not None:
+            return bound
+
+    if owner in facts.factories:
+        returned = facts.factories[owner]
+        bound = _resolve_named_str_attr(
+            file_path,
+            returned,
+            attr,
+            facts_by_file,
+            aliases_by_file,
+            file_set,
+            seen,
+        )
+        if bound is not None:
+            return bound
+        imported_return = aliases_by_file.get(file_path, {}).get(returned)
+        if imported_return is not None:
+            module, orig = imported_return
+            target = _find_module_file(module, file_set)
+            if target is not None:
+                bound = _resolve_named_str_attr(
+                    target,
+                    orig,
+                    attr,
+                    facts_by_file,
+                    aliases_by_file,
+                    file_set,
+                    seen,
+                )
+                if bound is not None:
+                    return bound
+        unique = _unique_class_attr(returned, attr, facts_by_file)
+        if unique is not None:
+            return unique
+
+    imported = aliases_by_file.get(file_path, {}).get(owner)
     if imported is None:
         return None
     module, orig = imported
     target = _find_module_file(module, file_set)
     if target is None:
         return None
-    found = lookup(target, orig)
-    if found is not None:
-        return found
-    facts = facts_by_file.get(target)
-    if facts is None:
+    bound = _resolve_named_str_attr(
+        target,
+        orig,
+        attr,
+        facts_by_file,
+        aliases_by_file,
+        file_set,
+        seen,
+    )
+    if bound is not None:
+        return bound
+    target_facts = facts_by_file.get(target)
+    if target_facts is None:
         return None
-    values = {value for (cls, name), value in facts.class_str_attrs.items() if name == attr}
-    values.update(value for name, value in facts.module_str_attrs.items() if name == attr)
+    values = {value for (cls, name), value in target_facts.class_str_attrs.items() if name == attr}
+    values.update(value for name, value in target_facts.module_str_attrs.items() if name == attr)
     if len(values) == 1:
         return next(iter(values))
+    return None
+
+
+def _unique_class_attr(
+    class_name: str, attr: str, facts_by_file: dict[str, _FileFacts]
+) -> str | None:
+    values: set[str] = set()
+    for facts in facts_by_file.values():
+        found = facts.class_str_attrs.get((class_name, attr))
+        if found is not None:
+            values.add(found)
+    if len(values) == 1:
+        return next(iter(values))
+    return None
+
+
+def _is_no_arg_factory(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    positional = list(node.args.args)
+    if positional and positional[0].arg in {"self", "cls"}:
+        return False
+    if len(positional) > len(node.args.defaults):
+        return False
+    return all(default is not None for default in node.args.kw_defaults)
+
+
+def _type_name(node: ast.AST | None) -> str | None:
+    if node is None:
+        return None
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _factory_return_class(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
+    if not _is_no_arg_factory(node):
+        return None
+    names: set[str] = set()
+    annotated = _type_name(node.returns)
+    if annotated and annotated not in _ROUTER_CTORS:
+        names.add(annotated)
+    for walked in ast.walk(node):
+        if not isinstance(walked, ast.Return) or walked.value is None:
+            continue
+        ctor = _call_ctor_name(walked.value)
+        if ctor and ctor not in _ROUTER_CTORS:
+            names.add(ctor)
+            continue
+        named = _type_name(walked.value)
+        if named and named not in _ROUTER_CTORS:
+            names.add(named)
+    if len(names) == 1:
+        return next(iter(names))
     return None
 
 

--- a/repo_wiki/scanner/multi_runtime_scanner_v3.py
+++ b/repo_wiki/scanner/multi_runtime_scanner_v3.py
@@ -21,7 +21,7 @@ from typing import Any
 from repo_wiki.core.config import RepoWikiConfig
 from repo_wiki.orchestration.release_meta_schema import SCHEMA_VERSION_SOURCE_INVENTORY
 from repo_wiki.scanner.artifacts import is_product_source_path
-from repo_wiki.scanner.fastapi_routes import extract_fastapi_endpoints
+from repo_wiki.scanner.fastapi_routes import FastAPIEndpoint, extract_fastapi_endpoints
 from repo_wiki.scanner.repository_scanner import RepositoryScanner
 
 # ---------------------------------------------------------------------------
@@ -201,6 +201,46 @@ def _scan_python(text: str, rel: str, record: FileScanRecord) -> None:
                 "evidence_path": rel,
             }
         )
+
+
+def _record_has_fastapi_service(record: dict[str, Any]) -> bool:
+    return any(item.get("kind") == "python_fastapi_app" for item in record.get("services", []))
+
+
+def _fastapi_surface(endpoint: FastAPIEndpoint) -> dict[str, Any]:
+    return {
+        "runtime": "python",
+        "method": endpoint.method,
+        "path": endpoint.path,
+        "handler": endpoint.handler,
+        "evidence_path": endpoint.file_path,
+    }
+
+
+def _with_full_repo_fastapi_surfaces(
+    cached_records: dict[str, dict[str, Any]],
+    python_files: list[tuple[str, str]],
+) -> dict[str, dict[str, Any]]:
+    """Replace per-file FastAPI routes with one full-repo extract (joined prefixes)."""
+    endpoints = extract_fastapi_endpoints(python_files)
+    by_file: dict[str, list[FastAPIEndpoint]] = {}
+    for endpoint in endpoints:
+        by_file.setdefault(endpoint.file_path, []).append(endpoint)
+
+    overlayed: dict[str, dict[str, Any]] = {}
+    for path, record in cached_records.items():
+        if path not in by_file and not _record_has_fastapi_service(record):
+            overlayed[path] = record
+            continue
+        copied = dict(record)
+        copied["api_surfaces"] = [
+            item for item in record.get("api_surfaces", []) if item.get("runtime") != "python"
+        ]
+        copied["api_surfaces"].extend(
+            _fastapi_surface(endpoint) for endpoint in by_file.get(path, [])
+        )
+        overlayed[path] = copied
+    return overlayed
 
 
 def _scan_js_ts(text: str, rel: str, record: FileScanRecord) -> None:
@@ -472,6 +512,7 @@ class MultiRuntimeSourceScannerV3:
 
         current_paths: set[str] = set()
         current_hashes: dict[str, str] = {}
+        python_files: list[tuple[str, str]] = []
 
         for batch in self._legacy.iter_file_batches(batch_size=batch_size):
             batches_processed += 1
@@ -483,6 +524,8 @@ class MultiRuntimeSourceScannerV3:
                 text = sf.text
                 digest = _sha256_text(text)
                 current_hashes[rel_s] = digest
+                if rel.suffix.lower() == ".py" and is_product_source_path(rel_s):
+                    python_files.append((rel_s, text))
 
                 if incremental and hashes.get(rel_s) == digest and rel_s in cached_records:
                     record_dict = cached_records[rel_s]
@@ -538,8 +581,9 @@ class MultiRuntimeSourceScannerV3:
         frontend_callers: list[dict[str, Any]] = []
         deployment_assets: list[dict[str, Any]] = []
         tests: list[dict[str, Any]] = []
+        inventory_records = _with_full_repo_fastapi_surfaces(cached_records, python_files)
 
-        for _path, rec in sorted(cached_records.items()):
+        for _path, rec in sorted(inventory_records.items()):
             _merge_lists(services, rec.get("services", []))
             _merge_lists(api_surfaces, rec.get("api_surfaces", []))
             _merge_lists(data_models, rec.get("data_models", []))

--- a/tests/test_fastapi_router_inventory.py
+++ b/tests/test_fastapi_router_inventory.py
@@ -5,12 +5,130 @@ from __future__ import annotations
 from pathlib import Path
 
 from repo_wiki.core.config import RepoWikiConfig
+from repo_wiki.scanner.multi_runtime_scanner_v3 import scan_repository_source_inventory_v3
 from repo_wiki.scanner.repository_scanner import RepositoryScanner
 
 
 def _scan(root: Path):
     cfg = RepoWikiConfig.model_validate({"project": {"root": str(root)}})
     return RepositoryScanner(cfg).scan()
+
+
+def _endpoint_pairs(snapshot) -> set[tuple[str, str]]:
+    return {(endpoint.method, endpoint.path) for endpoint in snapshot.endpoints}
+
+
+def _v3_endpoint_pairs(root: Path) -> set[tuple[str, str]]:
+    inventory = scan_repository_source_inventory_v3(root, incremental=False)
+    return {
+        (str(item["method"]).upper(), str(item["path"]))
+        for item in inventory["api_surfaces"]
+        if item.get("method") and item.get("path")
+    }
+
+
+def _write_realworld_fastapi_tree(root: Path) -> None:
+    """Multi-file FastAPI tree matching nsidnev RealWorld mount/settings shape."""
+    settings_dir = root / "app" / "core" / "settings"
+    routes = root / "app" / "api" / "routes"
+    settings_dir.mkdir(parents=True)
+    routes.mkdir(parents=True)
+    (root / "app" / "__init__.py").write_text("", encoding="utf-8")
+    (root / "app" / "core" / "__init__.py").write_text("", encoding="utf-8")
+    (root / "app" / "api" / "__init__.py").write_text("", encoding="utf-8")
+    (routes / "__init__.py").write_text("", encoding="utf-8")
+    (settings_dir / "__init__.py").write_text("", encoding="utf-8")
+    (settings_dir / "app.py").write_text(
+        """
+class AppSettings:
+    api_prefix: str = "/api"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "app" / "core" / "config.py").write_text(
+        """
+from app.core.settings.app import AppSettings
+
+
+def get_app_settings():
+    return AppSettings()
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (routes / "authentication.py").write_text(
+        """
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.post("/login")
+async def login():
+    return {"token": "x"}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (routes / "articles.py").write_text(
+        """
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("")
+def list_articles():
+    return []
+
+
+@router.get("/feed")
+def get_feed():
+    return []
+
+
+@router.get("/{slug}")
+def get_article():
+    return {}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (routes / "api.py").write_text(
+        """
+from fastapi import APIRouter
+
+from app.api.routes import articles, authentication
+
+router = APIRouter()
+router.include_router(authentication.router, prefix="/users")
+router.include_router(articles.router, prefix="/articles")
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "app" / "main.py").write_text(
+        """
+from fastapi import FastAPI
+
+from app.api.routes.api import router as api_router
+from app.core.config import get_app_settings
+
+
+def get_application():
+    settings = get_app_settings()
+    application = FastAPI()
+    application.include_router(api_router, prefix=settings.api_prefix)
+    return application
+
+
+app = get_application()
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (root / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
 
 
 def test_include_router_prefix_is_joined_into_product_path(tmp_path: Path) -> None:
@@ -428,3 +546,45 @@ app = get_application()
         endpoint.method == "GET" and endpoint.path == "/articles/{slug}" for endpoint in get_eps
     )
     assert not any(endpoint.path == "/articles" for endpoint in get_eps)
+
+
+def test_factory_get_app_settings_resolves_api_prefix(tmp_path: Path) -> None:
+    """No-arg get_app_settings() returning AppSettings() must join api_prefix=/api."""
+    _write_realworld_fastapi_tree(tmp_path)
+    pairs = _endpoint_pairs(_scan(tmp_path))
+
+    assert ("POST", "/api/users/login") in pairs
+    assert ("GET", "/api/articles") in pairs
+    assert ("GET", "/api/articles/feed") in pairs
+    assert ("GET", "/api/articles/{slug}") in pairs
+    assert ("POST", "/login") not in pairs
+    assert ("POST", "/users/login") not in pairs
+
+
+def test_v3_inventory_joins_cross_file_and_settings_factory_prefix(tmp_path: Path) -> None:
+    """v3 must scan the full Python set once so include_router prefixes survive."""
+    _write_realworld_fastapi_tree(tmp_path)
+    pairs = _v3_endpoint_pairs(tmp_path)
+
+    assert ("POST", "/api/users/login") in pairs
+    assert ("GET", "/api/articles") in pairs
+    assert ("GET", "/api/articles/feed") in pairs
+    assert ("GET", "/api/articles/{slug}") in pairs
+    assert ("POST", "/login") not in pairs
+    assert ("POST", "/users/login") not in pairs
+
+
+def test_v3_and_repository_scanner_agree_on_mounted_fastapi_paths(tmp_path: Path) -> None:
+    _write_realworld_fastapi_tree(tmp_path)
+    scanner_pairs = _endpoint_pairs(_scan(tmp_path))
+    v3_pairs = _v3_endpoint_pairs(tmp_path)
+    mounted = {
+        ("POST", "/api/users/login"),
+        ("GET", "/api/articles"),
+        ("GET", "/api/articles/feed"),
+        ("GET", "/api/articles/{slug}"),
+    }
+
+    assert mounted <= scanner_pairs
+    assert mounted <= v3_pairs
+    assert scanner_pairs & mounted == v3_pairs & mounted


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Round-3 FastAPI RealWorld evidence: generate/wiki (RepositoryScanner, full-repo extract) already had mounted paths such as `POST /users/login`, but v3 `source-inventory.json` / verify owner still listed relative routes (`POST /login`). That left 14 relative API paths with no owner. Separately, `prefix=settings.api_prefix` from `settings = get_app_settings()` was still dropped, so `/api` never joined.

This PR fixes both:

1. **v3 full-repo FastAPI scan** — `MultiRuntimeSourceScannerV3` collects the same product `.py` file list RepositoryScanner uses, calls `extract_fastapi_endpoints` once on the whole set, then attaches endpoints to their defining files. Empty `""` paths still become `/`. Handler binding from #43/#45 is unchanged.
2. **Settings factory `api_prefix`** — scanner follows a no-arg factory (`get_app_settings()` returning `AppSettings()` / annotated `api_prefix: str = "/api"`). If it cannot resolve, it keeps the already-joined literal prefix (`/users`) and does not invent paths.

A RealWorld-shaped fixture now inventories `POST /api/users/login` and `/api/articles/...` when `api_prefix="/api"` is on the settings class. RepositoryScanner and v3 agree on those mounted paths.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (typos, docs, etc.)
- [ ] Refactoring (no functional changes)
- [x] Tests (adding or updating tests)

## Related Issue
Follow-up to #45 (already on main, `a3d58b4`). Does not relax HARD/SOFT verifier gates. Does not clone RealWorld/Flask into CI.

## Testing Performed
- [x] Ran tests locally: `pytest tests/test_fastapi_router_inventory.py tests/test_multi_runtime_scanner_v3.py tests/test_path_role_product_inventory.py tests/test_scanner_artifacts.py::TestMultiRuntimeSourceScannerV3`
- [x] Ran linting: `ruff format --check .` and `ruff check` on touched files
- [x] `mypy repo_wiki --ignore-missing-imports`

New TDD tests failed on current main (v3 had `POST /login`; scanner had `/users/login` without `/api`), then passed with the fix. Existing #43/#45 tests remain green.

## Checklist
- [x] My code follows the project's code style
- [x] I have performed self-review
- [x] I have commented complex code areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing FastAPI/v3 inventory tests pass locally

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed4aa6b1-fcfe-42fd-8067-36eb72490509?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed4aa6b1-fcfe-42fd-8067-36eb72490509&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

