### PR TITLE
fix: resolve FastAPI settings.api_prefix through env factory return

### DIFF
--- a/repo_wiki/scanner/fastapi_routes.py
+++ b/repo_wiki/scanner/fastapi_routes.py
@@ -462,9 +462,22 @@ def _type_name(node: ast.AST | None) -> str | None:
     return None
 
 
+def _function_assigned_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    names: set[str] = set()
+    for stmt in node.body:
+        if isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+        elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            names.add(stmt.target.id)
+    return names
+
+
 def _factory_return_class(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
     if not _is_no_arg_factory(node):
         return None
+    local_names = _function_assigned_names(node)
     names: set[str] = set()
     annotated = _type_name(node.returns)
     if annotated and annotated not in _ROUTER_CTORS:
@@ -473,14 +486,19 @@ def _factory_return_class(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str |
         if not isinstance(walked, ast.Return) or walked.value is None:
             continue
         ctor = _call_ctor_name(walked.value)
-        if ctor and ctor not in _ROUTER_CTORS:
+        if ctor and ctor not in _ROUTER_CTORS and ctor not in local_names:
             names.add(ctor)
             continue
         named = _type_name(walked.value)
-        if named and named not in _ROUTER_CTORS:
+        if named and named not in _ROUTER_CTORS and named not in local_names:
             names.add(named)
     if len(names) == 1:
         return next(iter(names))
+    # RealWorld: `-> AppSettings` plus `return config()` is not unique; keep the
+    # annotation. Prefix lookup later succeeds only if that class has a string
+    # constant attr (e.g. api_prefix="/api"); otherwise no prefix is invented.
+    if annotated and annotated not in _ROUTER_CTORS:
+        return annotated
     return None
 
 

--- a/tests/test_fastapi_router_inventory.py
+++ b/tests/test_fastapi_router_inventory.py
@@ -131,6 +131,48 @@ app = get_application()
     (root / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
 
 
+def _write_realworld_env_factory_fastapi_tree(root: Path) -> None:
+    """RealWorld config factory: annotation AppSettings plus ``return config()``."""
+    _write_realworld_fastapi_tree(root)
+    (root / "app" / "core" / "config.py").write_text(
+        """
+from enum import Enum
+from functools import lru_cache
+
+from app.core.settings.app import AppSettings
+
+
+class AppEnv(str, Enum):
+    prod = "prod"
+    dev = "dev"
+
+
+class BaseAppSettings:
+    app_env: AppEnv = AppEnv.prod
+
+
+class DevSettings(AppSettings):
+    pass
+
+
+class ProdSettings(AppSettings):
+    pass
+
+
+environments = {AppEnv.prod: ProdSettings, AppEnv.dev: DevSettings}
+
+
+@lru_cache
+def get_app_settings() -> AppSettings:
+    app_env = BaseAppSettings().app_env
+    config = environments[app_env]
+    return config()
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 def test_include_router_prefix_is_joined_into_product_path(tmp_path: Path) -> None:
     (tmp_path / "app").mkdir()
     (tmp_path / "app" / "main.py").write_text(
@@ -588,3 +630,15 @@ def test_v3_and_repository_scanner_agree_on_mounted_fastapi_paths(tmp_path: Path
     assert mounted <= scanner_pairs
     assert mounted <= v3_pairs
     assert scanner_pairs & mounted == v3_pairs & mounted
+
+
+def test_env_dict_factory_return_config_resolves_api_prefix(tmp_path: Path) -> None:
+    """Annotation AppSettings plus ``return config()`` must still join api_prefix=/api."""
+    _write_realworld_env_factory_fastapi_tree(tmp_path)
+    scanner_pairs = _endpoint_pairs(_scan(tmp_path))
+    v3_pairs = _v3_endpoint_pairs(tmp_path)
+
+    for pairs in (scanner_pairs, v3_pairs):
+        assert ("POST", "/api/users/login") in pairs
+        assert ("POST", "/login") not in pairs
+        assert ("POST", "/users/login") not in pairs


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Follow-up to #46. v3 now agrees with RepositoryScanner on 19 mounted paths, but `/api` is still missing on nsidnev/fastapi-realworld-example-app.

#46’s factory fixture used `return AppSettings()` (unique name). The real factory is:

```python
@lru_cache
def get_app_settings() -> AppSettings:
    app_env = BaseAppSettings().app_env
    config = environments[app_env]
    return config()
```

Measured on installed `fastapi_routes.py` @ 24b36a1 (r3-after-46):

- `_factory_return_class(get_app_settings) = None`
- `facts.factories = {}` for `config.py`
- `_resolve_prefix_ref(..., 'settings.api_prefix') = None`
- `_factory_return_class` requires `len(names)==1`
- annotation adds `AppSettings`; `return config()` adds ctor name `config`
- `names={'AppSettings','config'}` => None, factory dropped

`AppSettings.api_prefix: str = "/api"` exists and the scanner already records `class_str_attrs[('AppSettings','api_prefix')] = '/api'`.

## Fix

`_factory_return_class` now:

1. Ignores constructor names assigned locally in the factory (`config = environments[app_env]; return config()`).
2. If names are still not unique, prefers the annotated return class (`AppSettings`).
3. Does not invent a prefix: `_resolve_prefix_ref` still only uses the class when `api_prefix` is a recorded string constant.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (adding or updating tests)

## Related Issue
Follow-up after PR #46. Not a merge of #46.

## Out of scope
- Overview/init-stub identity
- citation `file:` prefix
- 529 circuit-break
- Copying RealWorld/Flask clones into the repo or CI
- Relaxing HARD/SOFT
- Wiki templates

## Testing Performed
- [x] TDD: `test_env_dict_factory_return_config_resolves_api_prefix` failed on current main (`POST /users/login` only; no `/api`), then passed after the fix
- [x] `pytest tests/test_fastapi_router_inventory.py` — 12 passed (existing #43/#45/#46 tests stay green)
- [x] `ruff format --check .`
- [x] `mypy repo_wiki --ignore-missing-imports`

## Checklist
- [x] TDD: RealWorld-shaped factory test added first
- [x] Implementation makes `POST /api/users/login` appear (not only `/users/login` or `/login`)
- [x] Existing #43/#45/#46 tests stay green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abfc5017-61f9-4fff-a4be-5de221c7ff21?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abfc5017-61f9-4fff-a4be-5de221c7ff21&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

