### PR TITLE
fix: owner mapping for mounted FastAPI /api paths

### DIFF
--- a/repo_wiki/verifier/ownership_coverage.py
+++ b/repo_wiki/verifier/ownership_coverage.py
@@ -15,6 +15,17 @@ class OwnerInventoryItem:
     kind: str
     identifier: str
     source: str
+    defining_file: str = ""
+    defining_handler: str = ""
+
+
+@dataclass(frozen=True)
+class ApiOwnerBinding:
+    """Mounted ``METHOD path`` bound to the handler file that defines it."""
+
+    identifier: str
+    defining_file: str
+    defining_handler: str
 
 
 OWNER_HINT_PATTERN = re.compile(
@@ -39,6 +50,33 @@ def collect_owner_inventory_items(meta_root: Path) -> list[OwnerInventoryItem]:
     for item in items:
         deduped[(item.kind, item.identifier)] = item
     return list(deduped.values())
+
+
+def map_mounted_api_owners(surfaces: Any) -> dict[str, ApiOwnerBinding]:
+    """Join inventory surfaces to mounted ``METHOD path`` owner keys.
+
+    Stub: current main never joins handler/file onto mounted FastAPI paths.
+    """
+    return {}
+
+
+def owner_coverage_gaps(
+    items: list[OwnerInventoryItem],
+    pages: list[str],
+    warnings: set[Any],
+) -> list[OwnerInventoryItem]:
+    """Return inventory items that still lack owner mapping or UNIDENTIFIED warning."""
+    missing: list[OwnerInventoryItem] = []
+    for item in items:
+        covered = (item.kind, item.identifier) in warnings or item.identifier in warnings
+        if not covered:
+            for page_text in pages:
+                covered, _reason = page_has_owner_or_warning(page_text, item.identifier)
+                if covered:
+                    break
+        if not covered:
+            missing.append(item)
+    return missing
 
 
 def page_has_owner_or_warning(page_text: str, identifier: str) -> tuple[bool, str]:

--- a/repo_wiki/verifier/ownership_coverage.py
+++ b/repo_wiki/verifier/ownership_coverage.py
@@ -48,16 +48,34 @@ def collect_owner_inventory_items(meta_root: Path) -> list[OwnerInventoryItem]:
         _collect_runtime_entrypoints(data, source, items)
     deduped: dict[tuple[str, str], OwnerInventoryItem] = {}
     for item in items:
-        deduped[(item.kind, item.identifier)] = item
+        key = (item.kind, item.identifier)
+        existing = deduped.get(key)
+        if existing is None or (not _has_defining_owner(existing) and _has_defining_owner(item)):
+            deduped[key] = item
     return list(deduped.values())
 
 
 def map_mounted_api_owners(surfaces: Any) -> dict[str, ApiOwnerBinding]:
-    """Join inventory surfaces to mounted ``METHOD path`` owner keys.
-
-    Stub: current main never joins handler/file onto mounted FastAPI paths.
-    """
-    return {}
+    """Join scanned API surfaces to mounted ``METHOD path`` owner keys."""
+    bindings: dict[str, ApiOwnerBinding] = {}
+    if not surfaces:
+        return bindings
+    for item in surfaces:
+        method = _surface_str(item, ("method",))
+        path = _surface_str(item, ("path", "route", "url", "endpoint"))
+        if not method or not path:
+            continue
+        defining_file = _surface_str(item, ("file_path", "evidence_path", "handler_hint"))
+        defining_handler = _surface_str(item, ("handler",))
+        if not defining_file and not defining_handler:
+            continue
+        identifier = f"{method.upper()} {path}"
+        bindings[identifier] = ApiOwnerBinding(
+            identifier=identifier,
+            defining_file=defining_file,
+            defining_handler=defining_handler,
+        )
+    return bindings
 
 
 def owner_coverage_gaps(
@@ -68,15 +86,27 @@ def owner_coverage_gaps(
     """Return inventory items that still lack owner mapping or UNIDENTIFIED warning."""
     missing: list[OwnerInventoryItem] = []
     for item in items:
-        covered = (item.kind, item.identifier) in warnings or item.identifier in warnings
-        if not covered:
-            for page_text in pages:
-                covered, _reason = page_has_owner_or_warning(page_text, item.identifier)
-                if covered:
-                    break
+        covered, _reason = item_owner_coverage(item, pages, warnings)
         if not covered:
             missing.append(item)
     return missing
+
+
+def item_owner_coverage(
+    item: OwnerInventoryItem,
+    pages: list[str],
+    warnings: set[Any],
+) -> tuple[bool, str]:
+    """Return whether an inventory item has owner mapping, defining owner, or warning."""
+    if (item.kind, item.identifier) in warnings or item.identifier in warnings:
+        return True, "structured unidentified warning"
+    if item.kind == "api" and _has_defining_owner(item):
+        return True, "defining file/handler"
+    for page_text in pages:
+        covered, reason = page_has_owner_or_warning(page_text, item.identifier)
+        if covered:
+            return True, reason
+    return False, "identifier lacks owner mapping or UNIDENTIFIED warning"
 
 
 def page_has_owner_or_warning(page_text: str, identifier: str) -> tuple[bool, str]:
@@ -114,7 +144,18 @@ def _collect_apis(data: dict[str, Any], source: str, items: list[OwnerInventoryI
             visibility = str(item.get("visibility") or item.get("access") or "").lower()
             public = bool(item.get("public") is True or visibility == "public" or method and path)
             if method and path and public:
-                items.append(OwnerInventoryItem("api", f"{method.upper()} {path}", source))
+                items.append(
+                    OwnerInventoryItem(
+                        "api",
+                        f"{method.upper()} {path}",
+                        source,
+                        defining_file=_first_str(
+                            item, ("file_path", "evidence_path", "handler_hint")
+                        )
+                        or "",
+                        defining_handler=_first_str(item, ("handler",)) or "",
+                    )
+                )
 
 
 def _collect_models(data: dict[str, Any], source: str, items: list[OwnerInventoryItem]) -> None:
@@ -136,6 +177,18 @@ def _collect_runtime_entrypoints(
                     items.append(OwnerInventoryItem("runtime", identifier, source))
             elif isinstance(item, str) and item.strip():
                 items.append(OwnerInventoryItem("runtime", item.strip(), source))
+
+
+def _has_defining_owner(item: OwnerInventoryItem) -> bool:
+    return bool(item.defining_file.strip() or item.defining_handler.strip())
+
+
+def _surface_str(item: Any, keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = item.get(key) if isinstance(item, dict) else getattr(item, key, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
 
 
 def _is_core(item: dict[str, Any]) -> bool:

--- a/repo_wiki/verifier/qoder_strict_verifier.py
+++ b/repo_wiki/verifier/qoder_strict_verifier.py
@@ -1531,7 +1531,7 @@ class QoderLikeVerifierService(VerifierService):
         """Require every important inventory item to map to an owner page or UNIDENTIFIED warning."""
         from repo_wiki.verifier.ownership_coverage import (
             collect_owner_inventory_items,
-            page_has_owner_or_warning,
+            item_owner_coverage,
         )
 
         if not self._is_release_candidate_root():
@@ -1565,13 +1565,7 @@ class QoderLikeVerifierService(VerifierService):
         warnings = self._load_structured_unidentified_warnings(meta_root)
         missing: list[dict[str, str]] = []
         for item in items:
-            covered = (item.kind, item.identifier) in warnings or item.identifier in warnings
-            reason = "structured unidentified warning"
-            if not covered:
-                for page_text in pages:
-                    covered, reason = page_has_owner_or_warning(page_text, item.identifier)
-                    if covered:
-                        break
+            covered, reason = item_owner_coverage(item, pages, warnings)
             if not covered:
                 missing.append(
                     {

--- a/tests/test_fastapi_owner_mapping.py
+++ b/tests/test_fastapi_owner_mapping.py
@@ -21,7 +21,6 @@ from repo_wiki.verifier.ownership_coverage import (
     page_has_owner_or_warning,
 )
 from repo_wiki.verifier.qoder_strict_verifier import QoderLikeVerifierService
-
 from tests.test_fastapi_router_inventory import (
     _endpoint_pairs,
     _v3_endpoint_pairs,

--- a/tests/test_fastapi_owner_mapping.py
+++ b/tests/test_fastapi_owner_mapping.py
@@ -1,0 +1,207 @@
+"""Owner coverage must bind mounted FastAPI paths to defining file/handler.
+
+R7: after #46/#48 prefixes were correct, HARD QODER_OWNER_COVERAGE_MISSING
+still reported 19/19 `/api/*` owner-missing. Inventory identifiers were already
+`POST /api/users/login`; owner keys never joined to that mounted pair.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from repo_wiki.core.config import RepoWikiConfig
+from repo_wiki.scanner.multi_runtime_scanner_v3 import scan_repository_source_inventory_v3
+from repo_wiki.scanner.repository_scanner import RepositoryScanner
+from repo_wiki.verifier.ownership_coverage import (
+    OwnerInventoryItem,
+    collect_owner_inventory_items,
+    map_mounted_api_owners,
+    owner_coverage_gaps,
+    page_has_owner_or_warning,
+)
+from repo_wiki.verifier.qoder_strict_verifier import QoderLikeVerifierService
+
+from tests.test_fastapi_router_inventory import (
+    _endpoint_pairs,
+    _v3_endpoint_pairs,
+    _write_realworld_fastapi_tree,
+)
+
+
+def _scan(root: Path):
+    cfg = RepoWikiConfig.model_validate({"project": {"root": str(root)}})
+    return RepositoryScanner(cfg).scan()
+
+
+def _write_scanned_meta(meta_root: Path, api_surfaces: list[dict]) -> None:
+    meta_root.mkdir(parents=True, exist_ok=True)
+    (meta_root / "source-inventory.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "repo_agent.source_inventory/1.0",
+                "api_surfaces": api_surfaces,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_owner_mapping_joins_mounted_login_to_defining_handler(tmp_path: Path) -> None:
+    """Factory + settings.api_prefix=/api + /users + POST /login must own the mount."""
+    _write_realworld_fastapi_tree(tmp_path)
+    snapshot = _scan(tmp_path)
+    inventory = scan_repository_source_inventory_v3(tmp_path, incremental=False)
+
+    scanner_owners = map_mounted_api_owners(snapshot.endpoints)
+    v3_owners = map_mounted_api_owners(inventory["api_surfaces"])
+
+    for owners in (scanner_owners, v3_owners):
+        login = owners["POST /api/users/login"]
+        assert login.defining_handler == "login"
+        assert login.defining_file.replace("\\", "/").endswith("app/api/routes/authentication.py")
+        assert "POST /login" not in owners
+        assert "POST /users/login" not in owners
+
+
+def test_owner_coverage_does_not_report_mounted_login_missing(tmp_path: Path) -> None:
+    """R7 shape: pages mention POST /api/users/login without owner prose; inventory has owner."""
+    _write_realworld_fastapi_tree(tmp_path)
+    inventory = scan_repository_source_inventory_v3(tmp_path, incremental=False)
+    meta_root = tmp_path / "meta"
+    _write_scanned_meta(meta_root, inventory["api_surfaces"])
+
+    items = collect_owner_inventory_items(meta_root)
+    login = next(item for item in items if item.identifier == "POST /api/users/login")
+    assert login.kind == "api"
+    assert login.defining_handler == "login"
+    assert login.defining_file.replace("\\", "/").endswith("app/api/routes/authentication.py")
+
+    pages = [
+        "API参考列出 POST /api/users/login 与 GET /api/articles。",
+    ]
+    assert page_has_owner_or_warning(pages[0], "POST /api/users/login")[0] is False
+
+    missing = owner_coverage_gaps(items, pages, warnings=set())
+    missing_ids = {item.identifier for item in missing if item.kind == "api"}
+    assert "POST /api/users/login" not in missing_ids
+
+
+def test_owner_coverage_still_missing_without_defining_owner() -> None:
+    """Do not relax HARD: path-only APIs without file/handler stay owner-missing."""
+    orphan = OwnerInventoryItem(kind="api", identifier="GET /ghost", source="api-inventory.json")
+    missing = owner_coverage_gaps(
+        [orphan],
+        ["GET /ghost is listed in the API reference."],
+        warnings=set(),
+    )
+    assert [item.identifier for item in missing] == ["GET /ghost"]
+
+
+def test_prefix_join_inventory_stays_mounted(tmp_path: Path) -> None:
+    """Keep #43/#45/#46/#48 prefix-join behavior: inventory keys are /api/..., not /login."""
+    _write_realworld_fastapi_tree(tmp_path)
+    scanner_pairs = _endpoint_pairs(_scan(tmp_path))
+    v3_pairs = _v3_endpoint_pairs(tmp_path)
+    mounted = {("POST", "/api/users/login")}
+
+    assert mounted <= scanner_pairs
+    assert mounted <= v3_pairs
+    assert ("POST", "/login") not in scanner_pairs
+    assert ("POST", "/login") not in v3_pairs
+    assert ("POST", "/users/login") not in scanner_pairs
+    assert ("POST", "/users/login") not in v3_pairs
+
+
+def test_qoder_owner_check_accepts_inventory_defining_owner(tmp_path: Path) -> None:
+    """Verify HARD owner check must use the mounted-path → file/handler join."""
+    _write_realworld_fastapi_tree(tmp_path)
+    inventory = scan_repository_source_inventory_v3(tmp_path, incremental=False)
+
+    run_dir = tmp_path / ".repo-agent-eval" / "runs" / "run-owner-map"
+    content_dir = run_dir / "repowiki" / "zh" / "content"
+    meta_dir = run_dir / "repowiki" / "zh" / "meta"
+    content_dir.mkdir(parents=True)
+    meta_dir.mkdir(parents=True)
+    page_rel = "API参考/API参考.md"
+    page = content_dir / page_rel
+    page.parent.mkdir()
+    page.write_text(
+        "# API参考\n\n## 目录\n- [接口](#接口)\n\n## 接口\n\n"
+        "POST /api/users/login is listed in the API reference.\n",
+        encoding="utf-8",
+    )
+    (meta_dir / "quality-report.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "repo_agent.quality_report/1.0",
+                "summary": {"profile": "qoder-like", "grade": "PASS", "strict_mode": True},
+                "page_quality": [{"relative_path": page_rel, "quality_state": "READY"}],
+                "warnings": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (meta_dir / "page-registry.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "repo_agent.page_registry/1.0",
+                "generated_at": "2026-08-14T00:00:00Z",
+                "pages": [
+                    {
+                        "page_id": "api-reference",
+                        "relative_path": page_rel,
+                        "category": "api",
+                        "page_type": "content",
+                        "quality_state": "READY",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (meta_dir / "source-inventory.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "repo_agent.source_inventory/1.0",
+                "services": [{"service_id": "api-server"}],
+                "api_surfaces": inventory["api_surfaces"],
+                "data_models": [],
+                "runtime_entrypoints": [{"entrypoint": "uvicorn"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (meta_dir / "service-registry.json").write_text(
+        json.dumps({"services": [{"service_id": "api-server"}]}),
+        encoding="utf-8",
+    )
+    (meta_dir / "runtime-inventory.json").write_text(
+        json.dumps({"runtime_entrypoints": [{"entrypoint": "uvicorn"}]}),
+        encoding="utf-8",
+    )
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "version": "1.1",
+                "run_id": "run-owner-map",
+                "readiness_state": "READY",
+                "readiness_reasons": [],
+                "target_dirty": False,
+                "git_fresh": True,
+                "candidate_repowiki_zh_root": str(run_dir / "repowiki" / "zh"),
+                "candidate_content_root": str(content_dir),
+                "candidate_meta_root": str(meta_dir),
+                "report_paths": {"strict_verify": "reports/strict-verify-output.json"},
+                "files": [{"path": "reports/strict-verify-output.json"}],
+                "evidence": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    verifier = QoderLikeVerifierService(run_dir, strict=True)
+    check = verifier._check_qoder_owner_inventory_coverage()
+    missing = (check.details or {}).get("missing") or []
+    missing_ids = {item.get("identifier") for item in missing}
+    assert "POST /api/users/login" not in missing_ids


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

R7 measured HARD `QODER_OWNER_COVERAGE_MISSING` with **19/19 `/api/*` still owner-missing** after #46/#48 made inventory identifiers the mounted paths (`POST /api/users/login`, etc.). The relative-path bug did not regress — identifiers were already `/api/...`. Owner coverage never joined those keys to the defining file/handler already present on the inventory surface.

This PR binds owner coverage to the mounted FastAPI `(method, path)`:

- `map_mounted_api_owners` joins scan/v3 surfaces onto `POST /api/users/login` → `app/api/routes/authentication.py` / `login`
- `collect_owner_inventory_items` keeps `defining_file` / `defining_handler` on API items
- `QODER_OWNER_COVERAGE_MISSING` treats that join as owner mapping
- Path-only APIs without a defining file/handler still fail HARD

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (adding or updating tests)

## Related
- R7: 19/19 `/api/*` still owner-missing after prefixes were correct (`docs/eval/2026-08-14-fastapi-realworld-round7.md`)
- Does not clone RealWorld/Flask into CI
- Does not relax HARD/SOFT (`QODER_OWNER_COVERAGE_MISSING` stays HARD)

## Testing Performed
- [x] New tests failed on current main (RED): `POST /api/users/login` had no owner binding
- [x] Same tests pass after the join
- [x] Prefix-join tests (#43/#45/#46/#48) stay green (`tests/test_fastapi_router_inventory.py`)
- [x] Existing owner-gap verifier test still fails without defining owner / UNIDENTIFIED warning
- [x] `ruff format --check .`
- [x] `mypy repo_wiki --ignore-missing-imports`

## Out of scope
- file: citations (already #58)
- tests-as-product / taxonomy pages
- overview identity
- Copying the real clone
- 9 model owner-missing items from R7

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a746bf12-aa94-44ff-b12f-818e9a76882d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a746bf12-aa94-44ff-b12f-818e9a76882d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

