### PR TITLE
docs: FastAPI RealWorld round-8 eval after #58

### DIFF
--- a/docs/eval/2026-08-13-fastapi-realworld-wrap.md
+++ b/docs/eval/2026-08-13-fastapi-realworld-wrap.md
@@ -2,7 +2,7 @@
 
 **日期：** 2026-08-13–2026-08-14 CST  
 **对照：** nsidnev/fastapi-realworld-example-app `029eb778` × MiniMax-M3  
-**CLI：** r1 `9cadf85`（#40）→ r2 `c2407979`（#42 空 content 重试 + #43 FastAPI 扫描）→ r3 `a3d58b4`（#45 导入 router 前缀拼接）→ r4 `9328896`（#50；含 #48 `api_prefix` + #49 circuit-break）→ r5 `8912c89`（#52 README/身份优先于 init stub 与 eval notes）→ r6 `b0a06f4`（#54 README.rst 解析 + pyproject fallback）→ r7 `2e3a3f0`（#56 identity.description 流入 overview）
+**CLI：** r1 `9cadf85`（#40）→ r2 `c2407979`（#42 空 content 重试 + #43 FastAPI 扫描）→ r3 `a3d58b4`（#45 导入 router 前缀拼接）→ r4 `9328896`（#50；含 #48 `api_prefix` + #49 circuit-break）→ r5 `8912c89`（#52 README/身份优先于 init stub 与 eval notes）→ r6 `b0a06f4`（#54 README.rst 解析 + pyproject fallback）→ r7 `2e3a3f0`（#56 identity.description 流入 overview）→ r8 `05bb3b8`（#58 去掉 citation `file:` 前缀）
 
 第一轮评测见 `docs/eval/2026-08-13-fastapi-realworld-round1.md`。  
 第二轮评测见 `docs/eval/2026-08-13-fastapi-realworld-round2.md`。  
@@ -10,7 +10,8 @@
 第四轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round4.md`。  
 第五轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round5.md`。  
 第六轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round6.md`。  
-第七轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round7.md`。
+第七轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round7.md`。  
+第八轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round8.md`。
 
 ## r1 vs r2
 
@@ -46,7 +47,7 @@
 | owner missing | 21 | **23**（14 条 v3 相对路径 + 9 models） |
 | Overview Conduit | 否 | **否**（仍 api-gateway / init stub） |
 
-## 本回路已合并（#37–#56）
+## 本回路已合并（#37–#58）
 
 - **#37**（`98aa8bd`）：packaged templates、长 citation 路径、LLM 页超时跟 YAML/300s cap。
 - **#38**：Flask round-2 评测文档。
@@ -68,6 +69,8 @@
 - **#54**（`b0a06f4`）：跳过 RST badge / `:target:` / `:alt:`，读 README 第一段产品句；README 无产品句时回退 pyproject description。r6：identity.description 含 “passing Conduit testsuite”，无 `:target:` 垃圾；pyproject description **未读**（README 已是产品句）。00 仍无 Conduit、无产品名 RealWorld（仅 slug）；identity.description **未流入** 00 正文。引言引用 `README.rst:32-73`（Quickstart），跳过 L28 Conduit NOTE。
 - **#55**：FastAPI RealWorld round-6 评测文档。
 - **#56**（`2e3a3f0`）：identity.description 流入 overview context / composer prompt。r7：Overview **HIT Conduit**（中文「通过 Conduit 测试套件」）；`project-overview` 在 circuit-break 前完成（5288 tokens，PASS），#56 检查有效。不要重开 overview-identity PR。
+- **#57**：FastAPI RealWorld round-7 评测文档。
+- **#58**（`05bb3b8`）：去掉 wiki citation 的 `file:` 前缀。r8：`file:` = 0；新残差是字面量 `relpath:`。不要声称 #58 修好了 coverage。
 
 ## r3 vs r4
 
@@ -193,4 +196,35 @@
 - 可选：529 retry-before-circuit-break。不要松 HARD。
 - 产品契约本轮 **PASS**：index 与 wiki 均为 19/19 `/api/*`；`POST /api/users/login` HIT 14；API参考全部 19 条 `/api/*`。
 - r7 verify：**13 HARD / 0 SOFT**（与 r6 相同；未放宽）。不要松阈值。
+
+## r7 vs r8
+
+评测正文：`docs/eval/2026-08-14-fastapi-realworld-round8.md`。  
+verify JSON：`docs/eval/2026-08-14-fastapi-realworld-round8-verify.json`。
+
+| 项 | r7 | **r8** |
+|---|---|---|
+| CLI | `2e3a3f0` / #56 | **`05bb3b8` / #58** |
+| generate | 89/89；LLM 仅 37 | **89/89；LLM 89** |
+| cache | 0/89 | **0/89** |
+| fallback | 57 | **0** |
+| 529 / circuit-break | 4 / tripped | **0 / false** |
+| verify | 13 HARD / 0 SOFT | **12 HARD / 0 SOFT**（未放宽；`QODER_PROSE_TOO_LOW` 本轮 PASS） |
+| 页质量 | PASS 32 / DEGRADED 57 | **PASS 89 / DEGRADED 0** |
+| 无效 citation | 18（全部 `file:`） | **108**（`file:` = **0**；全部是字面量 `relpath:`） |
+| claim coverage | 17.75% | **42.28%**（MiniMax 健康回升，不是 #58 修好 coverage） |
+| owner missing | 28 | **29**（19 `/api/*` + 9 models + 1 service `db`） |
+| Overview Conduit | HIT | **HIT** |
+| wall | ~9m00s（后页 skip） | **~38m28s**（打完全部 89 页；不是变慢回归） |
+
+**#58 HIT**（`file:` = 0）。新残差是字面量 `relpath:` 模板。不要再为 `file:` 开重复 PR。coverage 回升是 provider 健康。本评测早于 #59。不要松 HARD/SOFT。
+
+## 残留（r8；不改 generator/scanner）
+
+- citation 字面量 `relpath:` — 108 HARD（`file:` 已清零）。
+- owner mapping 对已前缀的 `/api/*` 仍 19/19 缺失（this eval predates #59）。
+- tests-as-product：`核心服务/Tests.md`。
+- taxonomy 幻觉页；泄漏 `<think>` 89 页。
+- coverage 42.28% 仍 << 95%；eval-layout HARD；API mermaid 缺 9 / ER 缺 5。
+- r8 verify：**12 HARD / 0 SOFT**（未放宽）。不要松阈值。
 

--- a/docs/eval/2026-08-14-fastapi-realworld-round8-verify.json
+++ b/docs/eval/2026-08-14-fastapi-realworld-round8-verify.json
@@ -1,0 +1,29 @@
+{
+  "run_id": "run-1786694659163",
+  "cli": "repo-wiki 0.1.0 @ 05bb3b8c98d4e1634f5b227922b1952977c81b17",
+  "prs_included": ["#48", "#49", "#50", "#51", "#52", "#54", "#55", "#56", "#57", "#58"],
+  "profile": "qoder-like",
+  "ci_mode": true,
+  "strict_mode": true,
+  "grade": "FAIL",
+  "status": "NOT_READY",
+  "exit_code": 1,
+  "hard_fail": 12,
+  "soft_fail": 0,
+  "pages": {"total": 89, "pass": 89, "degraded": 0, "fallback": 0, "empty_llm_shells": 0, "llm_pass": 89},
+  "claim_coverage": {"covered": 1885, "total": 4458, "percent": "42.28%", "r7_percent": "17.75%"},
+  "citations": {
+    "invalid_count": 108,
+    "file_colon_prefix": 0,
+    "wiki_cite_blocks": 2680,
+    "wiki_bare_readme_rst_cites": 962,
+    "literal_relpath_placeholder": 83,
+    "relpath_prefixed_real_paths": 15
+  },
+  "overview_conduit": true,
+  "post_api_users_login": true,
+  "circuit_break_tripped": false,
+  "http_529": 0,
+  "owner_missing": 29,
+  "note": "#58 HIT (file: = 0). New residue is literal relpath: template. Do not claim gates relaxed. Coverage recovery is MiniMax health, not #58."
+}

--- a/docs/eval/2026-08-14-fastapi-realworld-round8.md
+++ b/docs/eval/2026-08-14-fastapi-realworld-round8.md
@@ -1,0 +1,105 @@
+# FastAPI RealWorld 对照 Wiki 第八轮评测
+
+**对照仓：** nsidnev/fastapi-realworld-example-app `029eb7781c60d5f563ee8990a0cbfb79b244538c`
+**产品：** RealWorld Conduit 后端（`/api/users` `/api/users/login` `/api/user` `/api/articles` … + JWT）
+**模型：** MiniMax-M3（openai-compat；非 MockLLM）
+**超时 / 并发：** YAML 180s，`max_concurrent=2`；circuit-break `max_provider_failures=3`
+**CLI：** repo-wiki 0.1.0 @ `05bb3b8c98d4e1634f5b227922b1952977c81b17`（PR **#58** / main）
+**时间：** 2026-08-14 16:04:18–16:42:46 CST（wall **38m28s**；compose 2306.3s）
+**run：** run-1786694659163
+
+Fresh LLM run：0/89 cache.
+
+## Index proof（#48 仍成立）
+
+`repo-wiki index` → 19 endpoints。scanner 19 `/api/*`。
+
+| | r7 (2e3a3f0 / #56) | **r8 (05bb3b8 / #58)** |
+|---|---|---|
+| endpoints | 19 `/api/*` | **19 `/api/*`** |
+| `POST /api/users/login` | HIT | **HIT** |
+| `GET /api/articles/feed` | HIT | **HIT** |
+| relative leftovers (`POST /login` `GET /feed`) | NONE | **NONE** |
+
+## Identity
+
+`resolve_repository_identity` after reinstall @ `05bb3b8`:
+- name: `fastapi-realworld-example-app`（pyproject.toml）
+- description includes "passing Conduit testsuite"
+- no `:target:` junk, no init-stub, no AGENTS.md / round*-report as product source
+
+## Generate
+
+exit 0。provider=openai（MiniMax-M3） mode=real。
+
+| 项 | r7 (#56) | **r8 (#58)** |
+|---|---|---|
+| generate | written 89/89；LLM 仅 37 | **written 89/89；LLM 89** |
+| LLM calls / tokens | 37 / 133487 | **89 / 366430** |
+| cache | 0/89 | **0/89** |
+| evidence spans | 350 | **350** |
+| empty LLM shells | 0 | **0** |
+| fallback | 57 | **0** |
+| 529 | 4 | **0** |
+| timeouts (180s) | 0 | **0** |
+| circuit-break tripped | `true`（#49 触发） | **`false`** |
+| empty assistant content | 0 | **0** |
+| UNRESOLVED_API_ENDPOINTS | 0 | **0** |
+| `POST /api/users/login` in wiki | 14 页 HIT | **14 页 HIT**；API参考列出全部 19 条 `/api/*` |
+| Overview=Conduit | HIT | **HIT**（简介 verbatim `passing Conduit testsuite` +「通过 Conduit 测试套件」） |
+| wall | ~9m00s | **~38m28s**（MiniMax 健康，打完全部 89 页） |
+
+quality: PASS 89 / DEGRADED 0。`failed_pages=[]`。
+
+**本轮未触发 circuit-break。** wall 38m vs r7 9m 不是变慢回归，是 r7 被 529 熔断砍掉后半程。不要把 fallback 57→0 或 coverage 回升解读成 #58 质量跃迁。
+
+## Verify
+
+verify_exit=**1**。HARD/SOFT **未放宽**。
+
+| | r7 | **r8** |
+|---|---|---|
+| exit / grade | 1 / FAIL NOT_READY | **1 / FAIL NOT_READY** |
+| HARD / SOFT | 13 / 0 | **12 / 0** |
+| 页数 | 89（PASS 32 / DEGRADED 57） | **89（PASS 89 / DEGRADED 0）** |
+| 无效 citation | 18（全部 `file:`） | **108**（listed 30；**`file:` = 0**；全部是字面量 `relpath:…`） |
+| claim coverage | **17.75%**（298/1679） | **42.28%**（1885/4458）— MiniMax 健康回升，仍远低于 95% |
+| page dumps | 25（listed 10） | **12**（listed 10）；全文 **89** 页含泄漏 `<think>` |
+| API mermaid 缺失 | 9 | **9** |
+| API aggregation | PASS | **PASS 13/13** |
+| owner missing | 28（19 `/api/*` + 9 models） | **29（19 `/api/*` + 9 models + 1 service `db`）** |
+| dirty-worktree | FAIL | FAIL（eval 产物） |
+| QODER_PROSE_TOO_LOW | FAIL ×3 | **PASS**（门仍是 HARD，本轮过了，不是门槛放松） |
+
+HARD codes: `QODER_MANIFEST_PATH_INVALID` `QODER_PAGE_QUALITY_STATE_MISSING` `QODER_UNRESOLVED_FACT_CONFLICT` `QODER_REQUIRED_INVENTORY_MISSING` `QODER_CITATION_INVALID` `QODER_CITATION_FACT_COVERAGE_LOW` `QODER_OWNER_COVERAGE_MISSING` `QODER_CITATION_RELEVANCE_MISMATCH` `QODER_API_MERMAID_MISSING` `QODER_DATA_MODEL_ER_MERMAID_MISSING` `QODER_PAGE_DUMP` `QODER_DIRTY_WORKTREE`。
+
+### #58 citation 结论
+
+**#58 HIT。** wiki 2680 个 `<cite>`：**0** 个 `file:` scheme；**962** 个裸 `README.rst:…`。r7 的 `file:README.rst` 「file does not exist」已消失。
+
+本轮 108 条无效 cite 是新残差：LLM 把 prompt 模板抄进正文——83 条字面量 `<cite>relpath:start-end</cite>`，15 条 `<cite>relpath:app/main.py:…</cite>`。值得另开 PR 剥 `relpath:`（对称 #58），**不要**再为 `file:` 开重复 PR。
+
+Owner：19 条 API 仍无 owner mapping（#59 later binds inventory defining file/handler; this eval predates #59 merge）。
+
+## Must-check
+
+1. Overview 是 RealWorld/Conduit？ **通过（#56 仍 HIT）。** 9 处 Conduit。无 init-stub。
+2. API 真实路由含 `/api`、不发明 `/health` `/webhook`？ **产品合同本轮通过。** UNRESOLVED 0。
+3. 数据模型 User/Article/Comment/Tag？ ER mermaid 仍缺 5 页。
+4. tests/docs 不当产品 api-server？ **未通过。** `核心服务/Tests.md` 仍在。
+5. Init stub 不当身份？ **通过。**
+6. eval 产物不当证据？ **#52 仍通过。**
+7. `file:` 前缀不当路径？ **#58 目标通过。**
+
+## 残留
+
+1. citation 字面量 `relpath:` — 108 HARD
+2. owner mapping 对已前缀的 `/api/*` 仍 19/19 缺失（this eval predates #59）
+3. tests-as-product — `核心服务/Tests.md`
+4. taxonomy 幻觉页
+5. 泄漏 `<think>` — 89 页
+6. coverage 42.28% 仍 << 95%
+7. eval-layout HARD
+8. API mermaid 缺 9 / ER 缺 5
+
+不要松 HARD/SOFT。coverage 回升是 provider 健康，不要声称 #58 修好了 coverage。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Docs-only FastAPI RealWorld round-8 wiki quality eval against nsidnev/fastapi-realworld-example-app `029eb778` × repo-wiki `0.1.0` @ `05bb3b8` (PR #58 / main).

**Do not merge until review.** No generator/verifier changes. HARD/SOFT not relaxed. Did not clone RealWorld/Flask.

### #58 HIT

- wiki 2680 `<cite>` blocks: **`file:` = 0**
- 962 bare `README.rst:…`
- r7 `file:README.rst` “file does not exist” is gone

### New residue

108 invalid cites are literal `relpath:` prompt-template copies (83 `<cite>relpath:start-end</cite>`, 15 `<cite>relpath:app/main.py:…</cite>`). Worth a follow-up that strips `relpath:` (symmetric to #58). **Do not** open another `file:` PR.

### Do not misread r8 vs r7

- verify still **FAIL / NOT_READY**, **12 HARD / 0 SOFT** (gates not relaxed; `QODER_PROSE_TOO_LOW` passed this run)
- coverage 17.75% → **42.28%** is MiniMax health (r7 was circuit-broken after 4×529), **not** an #58 quality jump
- wall ~38m vs r7 ~9m is a full 89-page LLM run, not a slowdown regression
- this eval predates #59

### Files

- `docs/eval/2026-08-14-fastapi-realworld-round8.md` (new; tables/numbers verbatim)
- `docs/eval/2026-08-14-fastapi-realworld-round8-verify.json` (new, compact)
- `docs/eval/2026-08-13-fastapi-realworld-wrap.md` (short r8 row/section only; earlier rounds unchanged)

## Type of Change

- [x] Documentation update (typos, docs, etc.)

## Related Issue

Eval follow-up to #58. Not an issue closer.

## Testing Performed

- [x] `ruff check .` and `ruff format --check .` (green; markdown excluded)
- [x] `pytest tests/test_stage0_ci_contract.py tests/test_eval_manifest.py tests/test_source_of_truth_contract.py`
- [x] `python scripts/secret_sentinel_scan.py README.md docs …` (0 findings)
- [x] Compact JSON parsed (`grade=FAIL`, `exit_code=1`, HARD 12 / SOFT 0, `file_colon_prefix=0`)
- [x] CI `docs-verify` and Stage 0 contract gate already green on this PR
- Diff is `docs/eval/*` only

## Checklist

- [x] Docs-only; no generator/verifier/HARD/SOFT changes
- [x] Tables and numbers kept exactly as recorded
- [x] Did not clone RealWorld/Flask
- [x] Self-review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11f0b7a0-c07c-4fca-8db5-43dc34bca699?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11f0b7a0-c07c-4fca-8db5-43dc34bca699&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

