### PR TITLE
docs: FastAPI RealWorld round-9 eval after #59+#61+#63+#64

### DIFF
--- a/docs/eval/2026-08-13-fastapi-realworld-wrap.md
+++ b/docs/eval/2026-08-13-fastapi-realworld-wrap.md
@@ -11,7 +11,8 @@
 第五轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round5.md`。  
 第六轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round6.md`。  
 第七轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round7.md`。  
-第八轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round8.md`。
+第八轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round8.md`。  
+第九轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round9.md`。
 
 ## r1 vs r2
 

--- a/docs/eval/2026-08-14-fastapi-realworld-round9-verify.json
+++ b/docs/eval/2026-08-14-fastapi-realworld-round9-verify.json
@@ -1,0 +1,20 @@
+{
+  "run_id": "run-1786712557785",
+  "cli": "repo-wiki 0.1.0 @ 395e4c4ecee45ebc9ea98125a3223d3216686b3b",
+  "prs_included": ["#59", "#61", "#63", "#64"],
+  "grade": "FAIL",
+  "hard_fail": 13,
+  "soft_fail": 0,
+  "pages": {"planned": 81, "written": 81, "pass": 67, "degraded": 14, "fallback": 14},
+  "think_pages": 0,
+  "relpath_leftover": 0,
+  "file_colon": 0,
+  "invalid_citations": 1,
+  "owner_missing_api": 0,
+  "owner_missing_models": 9,
+  "tests_md": false,
+  "empty_taxonomy_pages": false,
+  "overview_conduit": true,
+  "claim_coverage_percent": "49.93%",
+  "note": "#59 #61 #63 #64 HIT. Gates not relaxed. Prose FAIL x2 this run."
+}

--- a/docs/eval/2026-08-14-fastapi-realworld-round9.md
+++ b/docs/eval/2026-08-14-fastapi-realworld-round9.md
@@ -1,0 +1,50 @@
+# FastAPI RealWorld 对照 Wiki 第九轮评测
+
+**对照仓：** nsidnev/fastapi-realworld-example-app `029eb7781c60d5f563ee8990a0cbfb79b244538c`
+**CLI：** repo-wiki 0.1.0 @ `395e4c4ecee45ebc9ea98125a3223d3216686b3b`（#64 HEAD；含 #59 owner + #61 relpath + #63 think + #64 taxonomy）
+**时间：** 2026-08-14 21:02:37–21:24:09 CST（wall **21m32s**）
+**run：** run-1786712557785
+**模型：** MiniMax-M3，cache 0/81
+**verify JSON：** `docs/eval/2026-08-14-fastapi-realworld-round9-verify.json`
+
+第八轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round8.md`。  
+对照 wrap 见 `docs/eval/2026-08-13-fastapi-realworld-wrap.md`。
+
+## Index / identity
+
+19 `/api/*` including POST /api/users/login. No relative leftovers. Identity Conduit HIT. No `:target:` junk.
+
+## Generate vs r8
+
+| 项 | r8 | **r9** |
+|---|---|---|
+| planned / written | 89 / 89 | **81 / 81** |
+| LLM PASS / DEGRADED | 89 / 0 | **67 / 14** |
+| fallback | 0 | **14**（Insufficient prose，不是 529） |
+| 529 / circuit-break | 0 / false | **0 / false** |
+| Tests.md | 在 | **gone** |
+| Agent代理API / API网关 / 前端应用 / 服务网格 | 在 | **gone**（另少 微服务设计） |
+| `<think>` pages | 89 | **0** |
+| `file:` / `relpath:` leftover | 0 / 108 | **0 / 0** |
+| owner missing API | 19 `/api/*` | **0** |
+| Overview=Conduit | HIT | **HIT** |
+| wall | 38m28s | **21m32s** |
+
+#59 HIT（19 API owner 齐）. #61 HIT（relpath 0）. #63 HIT（think 0）. #64 HIT（8 个幻觉/测试页消失）.
+
+## Verify
+
+exit 1 / FAIL NOT_READY. HARD 13 / SOFT 0. Gates **not** relaxed. Prose HARD failed ×2 this run (r8 passed it).
+
+| | r8 | **r9** |
+|---|---|---|
+| 无效 citation | 108 | **1**（`README.md:1-3`；仓里是 README.rst） |
+| claim coverage | 42.28% | **49.93%**（764/1530）仍 << 95% |
+| page dumps | 12 + 89 think | **26**；0 think |
+| API / ER mermaid miss | 9 / 5 | **6 / 3** |
+| owner missing | 29 | **9 models only** |
+| QODER_PROSE_TOO_LOW | PASS | **FAIL ×2** |
+
+残留 9 个 model：DateTimeModelMixin IDModelMixin RWModel ArticlesFilters JWTMeta JWTUser ProfileInResponse TagsInList UserInUpdate.
+
+不要声称门槛放松。coverage 回升主要是 think 注水没了。

--- a/docs/plans/current-roadmap.md
+++ b/docs/plans/current-roadmap.md
@@ -22,7 +22,7 @@
 
 - qoder-like 隔离输出与 HARD/SOFT 门禁（不放宽）
 - FastAPI 对照闭环里已修：路由前缀 / `settings.api_prefix`、产品身份（README/pyproject → overview）、`file:` 引用、mounted `/api` owner 绑定（#43–#59）
-- Codex plugin #50；R8 评测见 `docs/eval/2026-08-14-fastapi-realworld-round8.md`
+- Codex plugin #50；R8 评测见 `docs/eval/2026-08-14-fastapi-realworld-round8.md`；R9 评测见 `docs/eval/2026-08-14-fastapi-realworld-round9.md`
 
 ## 本周期（先把单库 Wiki 做准）
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Docs-only FastAPI RealWorld round-9 wiki quality eval against nsidnev/fastapi-realworld-example-app `029eb778` × repo-wiki `0.1.0` @ `395e4c4` (#64 HEAD; includes #59 owner + #61 relpath + #63 think + #64 taxonomy).

**Do not merge until review.** No generator/verifier changes. HARD/SOFT not relaxed. Did not clone RealWorld/Flask.

### #59 #61 #63 #64 HIT

- #59: 19 `/api/*` owner 齐（owner missing API **0**）
- #61: `relpath:` leftover **0**（`file:` 仍为 0）
- #63: `<think>` pages **0**
- #64: Tests.md / Agent代理API / API网关 / 前端应用 / 服务网格 **gone**（另少 微服务设计）；planned/written **81 / 81**

### Verify still FAIL

- exit 1 / FAIL NOT_READY
- **HARD 13 / SOFT 0** — gates **not** relaxed
- `QODER_PROSE_TOO_LOW` **FAIL ×2** this run (r8 passed it)
- claim coverage **49.93%**（764/1530）仍 << 95%；回升主要是 think 注水没了
- 无效 citation **1**（`README.md:1-3`；仓里是 README.rst）
- owner missing **9 models only**

不要声称门槛放松。

### Files

- `docs/eval/2026-08-14-fastapi-realworld-round9.md` (new; tables/numbers verbatim)
- `docs/eval/2026-08-14-fastapi-realworld-round9-verify.json` (new, compact)
- `docs/eval/2026-08-13-fastapi-realworld-wrap.md` (one-line R9 pointer; earlier rounds unchanged)
- `docs/plans/current-roadmap.md` (one-line R9 pointer next to R8)

## Type of Change

- [x] Documentation update (typos, docs, etc.)

## Related Issue

Eval follow-up to #59+#61+#63+#64. Not an issue closer.

## Testing Performed

- [x] `ruff check .` and `ruff format --check .` (green; markdown excluded)
- [x] `pytest tests/test_stage0_ci_contract.py` (6 passed)
- [x] `python scripts/secret_sentinel_scan.py README.md docs .github repo_wiki scripts` (0 findings)
- [x] Compact JSON parsed (`grade=FAIL`, HARD 13 / SOFT 0, pages 81/81, think 0, relpath 0)
- [x] CI `docs-verify` green on this PR (also Stage 0, test 3.11/3.12, verify workflows, CodeQL)
- Diff is `docs/eval/*` + one-line roadmap pointer only

## Checklist

- [x] Docs-only; no generator/verifier/HARD/SOFT changes
- [x] Tables and numbers kept exactly as recorded
- [x] Did not clone RealWorld/Flask
- [x] Self-review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e4c22af-5dfe-4c33-b340-5c22c48bbe23?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e4c22af-5dfe-4c33-b340-5c22c48bbe23&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

