### PR TITLE
fix: owner mapping for scanned data-model types

### DIFF
--- a/repo_wiki/verifier/ownership_coverage.py
+++ b/repo_wiki/verifier/ownership_coverage.py
@@ -17,6 +17,7 @@ class OwnerInventoryItem:
     source: str
     defining_file: str = ""
     defining_handler: str = ""
+    defining_class: str = ""
 
 
 @dataclass(frozen=True)
@@ -26,6 +27,15 @@ class ApiOwnerBinding:
     identifier: str
     defining_file: str
     defining_handler: str
+
+
+@dataclass(frozen=True)
+class ModelOwnerBinding:
+    """Scanned data-model identifier bound to the file/class that defines it."""
+
+    identifier: str
+    defining_file: str
+    defining_class: str
 
 
 OWNER_HINT_PATTERN = re.compile(
@@ -78,6 +88,27 @@ def map_mounted_api_owners(surfaces: Any) -> dict[str, ApiOwnerBinding]:
     return bindings
 
 
+def map_scanned_model_owners(models: Any) -> dict[str, ModelOwnerBinding]:
+    """Join scanned Pydantic/data-model types to defining file/class owner keys."""
+    bindings: dict[str, ModelOwnerBinding] = {}
+    if not models:
+        return bindings
+    for item in models:
+        identifier = _surface_str(item, ("model_id", "id", "name", "display_name"))
+        defining_file = _surface_str(item, ("file_path", "evidence_path"))
+        defining_class = _surface_str(item, ("defining_class", "class_name", "name"))
+        if not identifier or not defining_file:
+            continue
+        if not defining_class:
+            defining_class = identifier
+        bindings[identifier] = ModelOwnerBinding(
+            identifier=identifier,
+            defining_file=defining_file,
+            defining_class=defining_class,
+        )
+    return bindings
+
+
 def owner_coverage_gaps(
     items: list[OwnerInventoryItem],
     pages: list[str],
@@ -102,6 +133,8 @@ def item_owner_coverage(
         return True, "structured unidentified warning"
     if item.kind == "api" and _has_defining_owner(item):
         return True, "defining file/handler"
+    if item.kind == "model" and _has_defining_owner(item):
+        return True, "defining file/class"
     for page_text in pages:
         covered, reason = page_has_owner_or_warning(page_text, item.identifier)
         if covered:
@@ -163,7 +196,21 @@ def _collect_models(data: dict[str, Any], source: str, items: list[OwnerInventor
         if isinstance(item, dict):
             identifier = _first_str(item, ("model_id", "id", "name", "display_name"))
             if identifier and _is_major(item):
-                items.append(OwnerInventoryItem("model", identifier, source))
+                defining_file = _first_str(item, ("file_path", "evidence_path")) or ""
+                defining_class = ""
+                if defining_file:
+                    defining_class = (
+                        _first_str(item, ("defining_class", "class_name", "name")) or identifier
+                    )
+                items.append(
+                    OwnerInventoryItem(
+                        "model",
+                        identifier,
+                        source,
+                        defining_file=defining_file,
+                        defining_class=defining_class,
+                    )
+                )
 
 
 def _collect_runtime_entrypoints(
@@ -180,6 +227,8 @@ def _collect_runtime_entrypoints(
 
 
 def _has_defining_owner(item: OwnerInventoryItem) -> bool:
+    if item.kind == "model":
+        return bool(item.defining_file.strip())
     return bool(item.defining_file.strip() or item.defining_handler.strip())
 
 

--- a/tests/test_fastapi_owner_mapping.py
+++ b/tests/test_fastapi_owner_mapping.py
@@ -21,6 +21,7 @@ from repo_wiki.verifier.ownership_coverage import (
     OwnerInventoryItem,
     collect_owner_inventory_items,
     map_mounted_api_owners,
+    map_scanned_model_owners,
     owner_coverage_gaps,
     page_has_owner_or_warning,
 )
@@ -221,8 +222,6 @@ def test_qoder_owner_check_accepts_inventory_defining_owner(tmp_path: Path) -> N
 
 def test_owner_mapping_joins_scanned_models_to_defining_file_class(tmp_path: Path) -> None:
     """Mixin/DTO inventory identifiers must join to defining file/class after scan."""
-    from repo_wiki.verifier.ownership_coverage import map_scanned_model_owners
-
     _write_realworld_fastapi_tree(tmp_path)
     snapshot = _scan(tmp_path)
     inventory = scan_repository_source_inventory_v3(tmp_path, incremental=False)

--- a/tests/test_fastapi_owner_mapping.py
+++ b/tests/test_fastapi_owner_mapping.py
@@ -1,8 +1,12 @@
-"""Owner coverage must bind mounted FastAPI paths to defining file/handler.
+"""Owner coverage must bind mounted FastAPI paths and scanned data-model types.
 
 R7: after #46/#48 prefixes were correct, HARD QODER_OWNER_COVERAGE_MISSING
 still reported 19/19 `/api/*` owner-missing. Inventory identifiers were already
 `POST /api/users/login`; owner keys never joined to that mounted pair.
+
+R9: after #59, those 19 `/api/*` owners are bound. Remaining HARD owner-missing
+is 9 scanned Pydantic types (mixins + DTOs). Inventory lists them; owner
+coverage does not join defining file/class.
 """
 
 from __future__ import annotations
@@ -33,17 +37,26 @@ def _scan(root: Path):
     return RepositoryScanner(cfg).scan()
 
 
-def _write_scanned_meta(meta_root: Path, api_surfaces: list[dict]) -> None:
+def _write_scanned_meta(
+    meta_root: Path,
+    api_surfaces: list[dict],
+    data_models: list[dict] | None = None,
+) -> None:
     meta_root.mkdir(parents=True, exist_ok=True)
     (meta_root / "source-inventory.json").write_text(
         json.dumps(
             {
                 "schema_version": "repo_agent.source_inventory/1.0",
                 "api_surfaces": api_surfaces,
+                "data_models": data_models or [],
             }
         ),
         encoding="utf-8",
     )
+
+
+def _model_defining_class(item: OwnerInventoryItem) -> str:
+    return getattr(item, "defining_class", "") or item.defining_handler
 
 
 def test_owner_mapping_joins_mounted_login_to_defining_handler(tmp_path: Path) -> None:
@@ -203,4 +216,162 @@ def test_qoder_owner_check_accepts_inventory_defining_owner(tmp_path: Path) -> N
     check = verifier._check_qoder_owner_inventory_coverage()
     missing = (check.details or {}).get("missing") or []
     missing_ids = {item.get("identifier") for item in missing}
+    assert "POST /api/users/login" not in missing_ids
+
+
+def test_owner_mapping_joins_scanned_models_to_defining_file_class(tmp_path: Path) -> None:
+    """Mixin/DTO inventory identifiers must join to defining file/class after scan."""
+    from repo_wiki.verifier.ownership_coverage import map_scanned_model_owners
+
+    _write_realworld_fastapi_tree(tmp_path)
+    snapshot = _scan(tmp_path)
+    inventory = scan_repository_source_inventory_v3(tmp_path, incremental=False)
+
+    scanner_owners = map_scanned_model_owners(snapshot.data_models)
+    v3_owners = map_scanned_model_owners(inventory["data_models"])
+
+    for owners in (scanner_owners, v3_owners):
+        mixin = owners["DateTimeModelMixin"]
+        dto = owners["UserInUpdate"]
+        assert mixin.defining_class == "DateTimeModelMixin"
+        assert mixin.defining_file.replace("\\", "/").endswith("app/models/rwmodel.py")
+        assert dto.defining_class == "UserInUpdate"
+        assert dto.defining_file.replace("\\", "/").endswith("app/models/schemas/users.py")
+
+
+def test_owner_coverage_does_not_report_scanned_models_missing(tmp_path: Path) -> None:
+    """R9 shape: pages name mixin/DTO without owner prose; inventory has defining owner."""
+    _write_realworld_fastapi_tree(tmp_path)
+    inventory = scan_repository_source_inventory_v3(tmp_path, incremental=False)
+    meta_root = tmp_path / "meta"
+    _write_scanned_meta(meta_root, inventory["api_surfaces"], inventory["data_models"])
+
+    items = collect_owner_inventory_items(meta_root)
+    mixin = next(item for item in items if item.identifier == "DateTimeModelMixin")
+    dto = next(item for item in items if item.identifier == "UserInUpdate")
+    assert mixin.kind == "model"
+    assert mixin.defining_file.replace("\\", "/").endswith("app/models/rwmodel.py")
+    assert _model_defining_class(mixin) == "DateTimeModelMixin"
+    assert dto.kind == "model"
+    assert dto.defining_file.replace("\\", "/").endswith("app/models/schemas/users.py")
+    assert _model_defining_class(dto) == "UserInUpdate"
+
+    pages = [
+        "数据模型列出 DateTimeModelMixin 与 UserInUpdate。",
+    ]
+    assert page_has_owner_or_warning(pages[0], "DateTimeModelMixin")[0] is False
+    assert page_has_owner_or_warning(pages[0], "UserInUpdate")[0] is False
+
+    missing = owner_coverage_gaps(items, pages, warnings=set())
+    missing_ids = {item.identifier for item in missing if item.kind == "model"}
+    assert "DateTimeModelMixin" not in missing_ids
+    assert "UserInUpdate" not in missing_ids
+
+
+def test_owner_coverage_still_missing_model_without_defining_owner() -> None:
+    """Do not relax HARD: identifier-only models without file/class stay owner-missing."""
+    orphan = OwnerInventoryItem(
+        kind="model", identifier="GhostModel", source="data-model-inventory.json"
+    )
+    missing = owner_coverage_gaps(
+        [orphan],
+        ["GhostModel is listed in the data-model reference."],
+        warnings=set(),
+    )
+    assert [item.identifier for item in missing] == ["GhostModel"]
+
+
+def test_qoder_owner_check_accepts_inventory_model_defining_owner(tmp_path: Path) -> None:
+    """Verify HARD owner check must use the model → file/class join."""
+    _write_realworld_fastapi_tree(tmp_path)
+    inventory = scan_repository_source_inventory_v3(tmp_path, incremental=False)
+
+    run_dir = tmp_path / ".repo-agent-eval" / "runs" / "run-owner-models"
+    content_dir = run_dir / "repowiki" / "zh" / "content"
+    meta_dir = run_dir / "repowiki" / "zh" / "meta"
+    content_dir.mkdir(parents=True)
+    meta_dir.mkdir(parents=True)
+    page_rel = "数据模型/数据模型.md"
+    page = content_dir / page_rel
+    page.parent.mkdir()
+    page.write_text(
+        "# 数据模型\n\n## 目录\n- [模型](#模型)\n\n## 模型\n\n"
+        "DateTimeModelMixin and UserInUpdate are listed in the data-model reference.\n",
+        encoding="utf-8",
+    )
+    (meta_dir / "quality-report.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "repo_agent.quality_report/1.0",
+                "summary": {"profile": "qoder-like", "grade": "PASS", "strict_mode": True},
+                "page_quality": [{"relative_path": page_rel, "quality_state": "READY"}],
+                "warnings": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (meta_dir / "page-registry.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "repo_agent.page_registry/1.0",
+                "generated_at": "2026-08-14T00:00:00Z",
+                "pages": [
+                    {
+                        "page_id": "data-models",
+                        "relative_path": page_rel,
+                        "category": "data-model",
+                        "page_type": "content",
+                        "quality_state": "READY",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (meta_dir / "source-inventory.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "repo_agent.source_inventory/1.0",
+                "services": [{"service_id": "api-server"}],
+                "api_surfaces": inventory["api_surfaces"],
+                "data_models": inventory["data_models"],
+                "runtime_entrypoints": [{"entrypoint": "uvicorn"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (meta_dir / "service-registry.json").write_text(
+        json.dumps({"services": [{"service_id": "api-server"}]}),
+        encoding="utf-8",
+    )
+    (meta_dir / "runtime-inventory.json").write_text(
+        json.dumps({"runtime_entrypoints": [{"entrypoint": "uvicorn"}]}),
+        encoding="utf-8",
+    )
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "version": "1.1",
+                "run_id": "run-owner-models",
+                "readiness_state": "READY",
+                "readiness_reasons": [],
+                "target_dirty": False,
+                "git_fresh": True,
+                "candidate_repowiki_zh_root": str(run_dir / "repowiki" / "zh"),
+                "candidate_content_root": str(content_dir),
+                "candidate_meta_root": str(meta_dir),
+                "report_paths": {"strict_verify": "reports/strict-verify-output.json"},
+                "files": [{"path": "reports/strict-verify-output.json"}],
+                "evidence": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    verifier = QoderLikeVerifierService(run_dir, strict=True)
+    check = verifier._check_qoder_owner_inventory_coverage()
+    missing = (check.details or {}).get("missing") or []
+    missing_ids = {item.get("identifier") for item in missing}
+    assert "DateTimeModelMixin" not in missing_ids
+    assert "UserInUpdate" not in missing_ids
     assert "POST /api/users/login" not in missing_ids

--- a/tests/test_fastapi_router_inventory.py
+++ b/tests/test_fastapi_router_inventory.py
@@ -128,7 +128,41 @@ app = get_application()
         + "\n",
         encoding="utf-8",
     )
+    _write_realworld_fastapi_models(root)
     (root / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+
+
+def _write_realworld_fastapi_models(root: Path) -> None:
+    """Mixin + request DTO matching RealWorld Pydantic inventory leftovers."""
+    models_dir = root / "app" / "models"
+    schemas_dir = models_dir / "schemas"
+    schemas_dir.mkdir(parents=True, exist_ok=True)
+    (models_dir / "__init__.py").write_text("", encoding="utf-8")
+    (schemas_dir / "__init__.py").write_text("", encoding="utf-8")
+    (models_dir / "rwmodel.py").write_text(
+        """
+from pydantic import BaseModel
+
+
+class DateTimeModelMixin(BaseModel):
+    created_at: str | None = None
+    updated_at: str | None = None
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (schemas_dir / "users.py").write_text(
+        """
+from pydantic import BaseModel
+
+
+class UserInUpdate(BaseModel):
+    username: str | None = None
+    email: str | None = None
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 def _write_realworld_env_factory_fastapi_tree(root: Path) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

R9 after #59: API owner-missing went **19 → 0** (`POST /api/users/login` and the other mounted `/api/*` paths now bind to defining file/handler). Remaining HARD `QODER_OWNER_COVERAGE_MISSING` is **9 scanned Pydantic/data-model types only**:

`DateTimeModelMixin`, `IDModelMixin`, `RWModel`, `ArticlesFilters`, `JWTMeta`, `JWTUser`, `ProfileInResponse`, `TagsInList`, `UserInUpdate`

Inventory already lists these mixins/DTOs. Owner coverage did not join defining file/class, so they stayed identifier-only and failed HARD unless a page named an owner.

This PR binds scanned model identifiers to defining file/class the same way #59 bound mounted FastAPI paths. Identifier-only models without a defining file/class still fail HARD. HARD/SOFT gates are not relaxed. RealWorld/Flask are not cloned into CI.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (adding or updating tests)

## Related Issue
R9 FastAPI RealWorld owner residual after #59.

## Testing Performed
- [x] New tests failed on current main (RED): mixin/DTO `defining_file` was empty; verify reported `DateTimeModelMixin` / `UserInUpdate` missing
- [x] Same tests pass after the join (GREEN)
- [x] #59 API owner tests and prefix-join tests stay green
- [x] `ruff format --check .` and `mypy repo_wiki --ignore-missing-imports` pass

## Checklist
- [x] Tests first: fixture FastAPI app + `DateTimeModelMixin` + `UserInUpdate`
- [x] Do not drop these models from inventory to pass the gate
- [x] Do not merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-310738d3-2d4a-475f-89af-cf1aeb518728?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-310738d3-2d4a-475f-89af-cf1aeb518728&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

