### PR TITLE
fix: resolve README.md cites to the actual readme file

### DIFF
--- a/repo_wiki/evidence/citation_renderer.py
+++ b/repo_wiki/evidence/citation_renderer.py
@@ -24,13 +24,55 @@ _DROP_CITATION_SCHEMES = ("file:", "path:", "relpath:")
 _PLACEHOLDER_CITE_BODY = "start-end"
 _CITE_BLOCK_RE = re.compile(r"(<cite>\s*)([^<]+?)(\s*</cite>)")
 _BRACKET_CITE_RE = re.compile(r"(\[cite:\s*)([^\]]+?)(\])")
+_CITE_PATH_SUFFIX_RE = re.compile(r"^(.+?)(:\d+(?:-\d+)?(?:\s*\([^)]+\))?)$")
+_ROOT_README_MD = "README.md"
+_ROOT_README_FALLBACKS = ("README.rst", "README.txt", "README")
+_ROOT_README_NAMES = (_ROOT_README_MD, *_ROOT_README_FALLBACKS)
 
 
-def normalize_citation_ref(raw: str) -> str:
+def unique_root_readme_name(workspace_root: str | Path | None) -> str | None:
+    """Return the only root README filename, or None if missing or ambiguous."""
+    if workspace_root is None:
+        return None
+    root = Path(workspace_root)
+    found = [name for name in _ROOT_README_NAMES if (root / name).is_file()]
+    if len(found) == 1:
+        return found[0]
+    return None
+
+
+def _remap_missing_readme_md(value: str, workspace_root: str | Path | None) -> str:
+    """Map a missing root README.md cite to the one real root readme, if unique."""
+    if workspace_root is None:
+        return value
+    root = Path(workspace_root)
+    prefix = ""
+    body = value
+    if body.lower().startswith("source:"):
+        prefix = "source:"
+        body = body[len("source:") :].lstrip()
+    match = _CITE_PATH_SUFFIX_RE.fullmatch(body)
+    if match:
+        path_text, suffix = match.group(1), match.group(2)
+    else:
+        path_text, suffix = body, ""
+    if path_text.replace("\\", "/") != _ROOT_README_MD:
+        return value
+    if (root / _ROOT_README_MD).is_file():
+        return value
+    found = [name for name in _ROOT_README_FALLBACKS if (root / name).is_file()]
+    if len(found) != 1:
+        return value
+    return f"{prefix}{found[0]}{suffix}"
+
+
+def normalize_citation_ref(raw: str, workspace_root: str | Path | None = None) -> str:
     """Return a citation target the verifier can resolve.
 
     Drops ``file:`` / ``path:`` / ``relpath:`` prefixes. Keeps ``source:`` and
     bare repo-relative paths, which already pass. Does not rewrite ``file://`` URIs.
+    When ``README.md`` is missing and exactly one of ``README.rst`` / ``README.txt``
+    / ``README`` exists at the repo root, remaps the cite to that file.
     """
     value = raw.strip()
     lowered = value.lower()
@@ -38,8 +80,9 @@ def normalize_citation_ref(raw: str) -> str:
         return value
     for scheme in _DROP_CITATION_SCHEMES:
         if lowered.startswith(scheme):
-            return value[len(scheme) :].lstrip()
-    return value
+            value = value[len(scheme) :].lstrip()
+            break
+    return _remap_missing_readme_md(value, workspace_root)
 
 
 def is_placeholder_citation_ref(raw: str) -> bool:
@@ -50,14 +93,14 @@ def is_placeholder_citation_ref(raw: str) -> bool:
     return value.lower() == _PLACEHOLDER_CITE_BODY
 
 
-def normalize_citation_markup(text: str) -> str:
+def normalize_citation_markup(text: str, workspace_root: str | Path | None = None) -> str:
     """Rewrite cite blocks/brackets so they do not emit file:/path:/relpath: prefixes."""
 
     def _rewrite(match: re.Match[str]) -> str:
         ref = match.group(2)
         if is_placeholder_citation_ref(ref):
             return ""
-        return f"{match.group(1)}{normalize_citation_ref(ref)}{match.group(3)}"
+        return f"{match.group(1)}{normalize_citation_ref(ref, workspace_root)}{match.group(3)}"
 
     rewritten = _CITE_BLOCK_RE.sub(_rewrite, text)
     return _BRACKET_CITE_RE.sub(_rewrite, rewritten)

--- a/repo_wiki/generator/composer.py
+++ b/repo_wiki/generator/composer.py
@@ -23,7 +23,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from repo_wiki.evidence.citation_renderer import CitationRenderer, normalize_citation_markup
+from repo_wiki.evidence.citation_renderer import (
+    CitationRenderer,
+    normalize_citation_markup,
+    unique_root_readme_name,
+)
 from repo_wiki.evidence.ranking import PageEvidenceBinding
 from repo_wiki.llm.config import LLMProviderConfig
 from repo_wiki.llm.models import ChatMessage, ChatRequest, ChatResponse, LLMProvider
@@ -467,6 +471,18 @@ class LLMPageComposer:
         raw = os.environ.get("REPO_WIKI_COMPACT_LLM_PROMPT", "1").strip().lower()
         return raw not in {"0", "false", "no", "off"}
 
+    def _root_readme_cite_rule(self) -> str:
+        name = unique_root_readme_name(self.workspace_root)
+        if name and name != "README.md":
+            return (
+                f"- 本仓库根 README 是 `{name}`。引用时写 `<cite>{name}:1-3</cite>`，"
+                "不要写不存在的 README.md。"
+            )
+        return (
+            "- 引用仓库根 README 时必须使用仓库中实际存在的文件名"
+            "（README.md / README.rst / README.txt / README），不要引用不存在的文件。"
+        )
+
     def _build_compact_prompt(self, input: ComposerInput, context: dict[str, Any]) -> str:
         page = input.page_plan
         required_headings = [
@@ -510,6 +526,7 @@ class LLMPageComposer:
 - 正文控制在 900 到 1400 个中文字符之间，避免长篇泛化。
 - 必须使用下面的源码证据，不允许编造不存在的模块、API 或版本。
 - 至少保留 3 个 `<cite>` 引用，格式为仓库相对路径加行号范围，例如 `<cite>src/app.py:1-10</cite>`。
+{self._root_readme_cite_rule()}
 - 使用段落解释为主，列表只用于核心组件或检查项。
 - 如果证据不足，明确写”当前证据显示”，不要过度推断。
 - 简介必须使用上面的产品身份描述，不要只写包名 slug 或运行时角色。
@@ -685,7 +702,7 @@ class LLMPageComposer:
             return f"# {title}\n\nLLM composer did not return content."
         if not stripped.startswith("#"):
             stripped = f"# {title}\n\n{stripped}"
-        return normalize_citation_markup(stripped)
+        return normalize_citation_markup(stripped, self.workspace_root)
 
     @property
     def provider_name(self) -> str:

--- a/repo_wiki/verifier/qoder_strict_verifier.py
+++ b/repo_wiki/verifier/qoder_strict_verifier.py
@@ -1944,7 +1944,7 @@ class QoderLikeVerifierService(VerifierService):
             is_source_looking_url,
         )
 
-        raw = normalize_citation_ref(citation)
+        raw = normalize_citation_ref(citation, self._source_root_for_citations())
         if is_source_looking_url(raw):
             return "source-looking external URL cannot validate repository lines"
         if is_external_url(raw):

--- a/tests/test_citation_file_prefix.py
+++ b/tests/test_citation_file_prefix.py
@@ -287,3 +287,111 @@ def test_compact_prompt_does_not_teach_relpath_scheme_cites() -> None:
     prompt = composer._build_compact_prompt(composer_input, composer._build_context(composer_input))
     assert "<cite>relpath:" not in prompt
     assert "relpath:start-end" not in prompt
+
+
+def test_normalize_readme_md_cite_to_readme_rst_when_only_rst_exists(tmp_path: Path) -> None:
+    """R9 leftover: LLM cites README.md on a README.rst-only repo; remap, do not invent README.md."""
+    (tmp_path / "README.rst").write_text("RealWorld Conduit example app\n" * 8, encoding="utf-8")
+    assert not (tmp_path / "README.md").exists()
+    composer = create_composer(workspace_root=tmp_path)
+    raw = _overview_page("README.md:1-3")
+    normalized = composer._normalize_markdown_response(raw, "Project Overview")
+
+    assert "<cite>README.rst:1-3</cite>" in normalized
+    assert "<cite>README.md:1-3</cite>" not in normalized
+    assert not (tmp_path / "README.md").exists()
+
+    _write_release_candidate(tmp_path, normalized)
+    result = QoderLikeVerifierService(tmp_path, strict=True).verify(ci=True)
+    citation_check = _citation_targets_check(result)
+    assert citation_check["status"] == "PASS"
+    assert citation_check["details"]["invalid_count"] == 0
+    assert "QODER_CITATION_INVALID" not in result.get("hard_gate_codes", [])
+    invalid = citation_check["details"].get("invalid") or []
+    assert not any("file does not exist" in str(item.get("problem", "")) for item in invalid)
+
+
+def test_normalize_readme_md_cite_to_readme_txt_when_only_txt_exists(tmp_path: Path) -> None:
+    """Same alias when the only root readme is README.txt."""
+    (tmp_path / "README.txt").write_text("Conduit example app\n" * 8, encoding="utf-8")
+    assert not (tmp_path / "README.md").exists()
+    composer = create_composer(workspace_root=tmp_path)
+    normalized = composer._normalize_markdown_response(
+        _overview_page("README.md:1-3"),
+        "Project Overview",
+    )
+
+    assert "<cite>README.txt:1-3</cite>" in normalized
+    assert "<cite>README.md:1-3</cite>" not in normalized
+
+    _write_release_candidate(tmp_path, normalized)
+    result = QoderLikeVerifierService(tmp_path, strict=True).verify(ci=True)
+    citation_check = _citation_targets_check(result)
+    assert citation_check["status"] == "PASS"
+    assert citation_check["details"]["invalid_count"] == 0
+    assert "QODER_CITATION_INVALID" not in result.get("hard_gate_codes", [])
+
+
+def test_readme_md_cite_stays_when_both_md_and_rst_exist(tmp_path: Path) -> None:
+    """Do not steal a real README.md cite when both README.md and README.rst exist."""
+    (tmp_path / "README.md").write_text("# Conduit\n\nFastAPI RealWorld.\n" * 4, encoding="utf-8")
+    (tmp_path / "README.rst").write_text("RealWorld Conduit example app\n" * 8, encoding="utf-8")
+    composer = create_composer(workspace_root=tmp_path)
+    normalized = composer._normalize_markdown_response(
+        _overview_page("README.md:1-3"),
+        "Project Overview",
+    )
+
+    assert "<cite>README.md:1-3</cite>" in normalized
+    assert "<cite>README.rst:1-3</cite>" not in normalized
+
+    _write_release_candidate(tmp_path, normalized)
+    result = QoderLikeVerifierService(tmp_path, strict=True).verify(ci=True)
+    citation_check = _citation_targets_check(result)
+    assert citation_check["status"] == "PASS"
+    assert citation_check["details"]["invalid_count"] == 0
+    assert "QODER_CITATION_INVALID" not in result.get("hard_gate_codes", [])
+
+
+def test_missing_app_nope_py_cite_still_hard_invalid(tmp_path: Path) -> None:
+    """A truly missing file stays HARD QODER_CITATION_INVALID; do not relax gates."""
+    (tmp_path / "README.rst").write_text("RealWorld Conduit example app\n" * 8, encoding="utf-8")
+    composer = create_composer(workspace_root=tmp_path)
+    page = composer._normalize_markdown_response(
+        _overview_page("app/nope.py:1"),
+        "Project Overview",
+    )
+    assert "<cite>app/nope.py:1</cite>" in page
+
+    _write_release_candidate(tmp_path, page)
+    result = QoderLikeVerifierService(tmp_path, strict=True).verify(ci=True)
+    assert "QODER_CITATION_INVALID" in result.get("hard_gate_codes", [])
+    citation_check = _citation_targets_check(result)
+    assert citation_check["status"] == "FAIL"
+    assert citation_check["reason_code"] == "QODER_CITATION_INVALID"
+    assert citation_check["gate_type"] == "HARD"
+
+
+def test_compact_prompt_teaches_actual_readme_rst_filename(tmp_path: Path) -> None:
+    """Composer should name the real root README so writers do not invent README.md."""
+    (tmp_path / "README.rst").write_text("RealWorld Conduit example app\n" * 8, encoding="utf-8")
+    composer = LLMPageComposer(workspace_root=tmp_path)
+    context = ComposerContext(
+        repository_name="demo",
+        primary_language="python",
+        framework="fastapi",
+        repository_root=str(tmp_path),
+    )
+    page = WikiPagePlan(
+        page_id="project-overview",
+        title="项目概述",
+        category=WikiTaxonomyCategory.PROJECT_OVERVIEW,
+        output_path="docs/pages/overview/project-overview.md",
+        generation_mode=GenerationMode.LLM_ASSISTED,
+    )
+    composer_input = build_composer_input(page, None, context)
+    prompt = composer._build_compact_prompt(composer_input, composer._build_context(composer_input))
+    assert "README.rst" in prompt
+    assert "<cite>README.md" not in prompt
+    assert "<cite>file:" not in prompt
+    assert "<cite>relpath:" not in prompt


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem (R9)

After #58/#61, FastAPI RealWorld invalid cites went 108 → **1**. The leftover was `<cite>README.md:1-3</cite>` / file does not exist. The clone's product readme is **README.rst** (no README.md). Identity already reads README.rst; the LLM still emits README.md.

## Fix

Citation normalize remaps a missing root `README.md` cite to the actual root readme (`README.rst`, `README.txt`, or `README`) when **exactly one** of those exists. The composer prompt also names the real file. The verifier uses the same remap so already-written pages pass.

Does **not**:
- invent `README.md` on disk
- steal a cite when both `README.md` and `README.rst` exist
- relax HARD/SOFT (`app/nope.py` stays `QODER_CITATION_INVALID` / HARD)
- clone RealWorld/Flask into CI

## Tests

- Fixture with only `README.rst`: `README.md:1-3` normalizes/verifies as `README.rst` (PASS)
- Same for `README.txt`
- Both `README.md` and `README.rst`: cite stays on `README.md`
- `app/nope.py` still HARD
- #58/#61 `file:` / `path:` / `relpath:` tests remain green

## Verification

- New tests failed on current main, then passed
- `ruff format --check .` passed
- `mypy repo_wiki --ignore-missing-imports` passed
- `tests/test_citation_file_prefix.py` and related citation tests passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecf2fff7-2fa6-4ef5-a340-2d71747fb7d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecf2fff7-2fa6-4ef5-a340-2d71747fb7d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

