### PR TITLE
fix: stop false HARD fails from quality-report aliases and dropped /runs

### DIFF
--- a/docs/plans/current-roadmap.md
+++ b/docs/plans/current-roadmap.md
@@ -21,7 +21,7 @@
 ## 已经落地（到 2026-08-14 main）
 
 - qoder-like 隔离输出与 HARD/SOFT 门禁（不放宽）
-- FastAPI 对照闭环里已修：路由前缀 / `settings.api_prefix`、产品身份（README/pyproject → overview）、`file:` 引用、mounted `/api` owner 绑定（#43–#59）
+- FastAPI 对照闭环里已修：路由前缀 / `settings.api_prefix`、产品身份（README/pyproject → overview）、`file:` 引用、mounted `/api` owner 绑定（#43–#59）；R11 leftover：quality-report `page_quality`/`pages` 别名不再误报 duplicate，qoder-like `--output .repo-agent-eval` 保留 `runs/`（门槛未放宽）
 - Codex plugin #50；R8 评测见 `docs/eval/2026-08-14-fastapi-realworld-round8.md`；R9 评测见 `docs/eval/2026-08-14-fastapi-realworld-round9.md`；R10 评测见 `docs/eval/2026-08-14-fastapi-realworld-round10.md`
 
 ## 本周期（先把单库 Wiki 做准）

--- a/repo_wiki/cli.py
+++ b/repo_wiki/cli.py
@@ -85,21 +85,18 @@ def generate_command(
     ci: bool = typer.Option(False, "--ci", help="Run in CI mode (strict verification)"),
 ) -> None:
     """Generate wiki content using specified eval profile."""
-    from repo_wiki.orchestration.eval_layout import get_eval_profile, reject_unsafe_output_root
+    from repo_wiki.orchestration.eval_layout import (
+        get_eval_profile,
+        override_eval_profile_root,
+        reject_unsafe_output_root,
+    )
 
     # Get the profile
     eval_profile = get_eval_profile(profile)
 
     # Override output root if specified
     if output:
-        from repo_wiki.orchestration.eval_layout import EvalOutputProfile
-
-        eval_profile = EvalOutputProfile(
-            name=profile,
-            root=output,
-            create_subdirs=eval_profile.create_subdirs,
-            content_subdir=eval_profile.content_subdir,
-        )
+        eval_profile = override_eval_profile_root(eval_profile, output)
         # Validate unsafe output roots
         reject_unsafe_output_root(output)
 
@@ -149,18 +146,12 @@ def improve_command(
         raise typer.BadParameter("improve currently supports --profile qoder-like only")
 
     from repo_wiki.orchestration.eval_layout import (
-        EvalOutputProfile,
         get_eval_profile,
+        override_eval_profile_root,
         reject_unsafe_output_root,
     )
 
-    eval_profile = get_eval_profile(profile)
-    eval_profile = EvalOutputProfile(
-        name=profile,
-        root=output,
-        create_subdirs=eval_profile.create_subdirs,
-        content_subdir=eval_profile.content_subdir,
-    )
+    eval_profile = override_eval_profile_root(get_eval_profile(profile), output)
     reject_unsafe_output_root(output)
 
     env_updates = {

--- a/repo_wiki/orchestration/eval_layout.py
+++ b/repo_wiki/orchestration/eval_layout.py
@@ -162,6 +162,26 @@ def get_eval_profile(name: str) -> EvalOutputProfile:
     return EVAL_PROFILES.get(name, EVAL_PROFILES["default"])
 
 
+def override_eval_profile_root(profile: EvalOutputProfile, output: str) -> EvalOutputProfile:
+    """Apply CLI `--output` while preserving the qoder-like `runs/` bucket.
+
+    `--output .repo-agent-eval` is the isolation root used by generate, verify,
+    and release-publish. The qoder-like profile stores candidate runs under
+    `<root>/runs/<run_id>/`. Replacing `profile.root` wholesale dropped `/runs`
+    and tripped `QODER_MANIFEST_PATH_INVALID` on the documented command.
+    """
+    root = Path(output)
+    if profile.name == "qoder-like" and root.name != "runs":
+        root = root / "runs"
+    return EvalOutputProfile(
+        name=profile.name,
+        root=str(root),
+        create_subdirs=profile.create_subdirs,
+        content_subdir=profile.content_subdir,
+        max_manifest_size_kb=profile.max_manifest_size_kb,
+    )
+
+
 def register_eval_profile(profile: EvalOutputProfile) -> None:
     """Register or update an eval profile."""
     EVAL_PROFILES[profile.name] = profile

--- a/repo_wiki/verifier/qoder_strict_verifier.py
+++ b/repo_wiki/verifier/qoder_strict_verifier.py
@@ -1660,6 +1660,7 @@ class QoderLikeVerifierService(VerifierService):
     ) -> tuple[dict[str, str], list[str]]:
         states: dict[str, str] = {}
         errors: list[str] = []
+        seen_in_container: dict[str, set[str]] = {key: set() for key in containers}
         for container_key in containers:
             items = payload.get(container_key)
             if items is None:
@@ -1679,12 +1680,19 @@ class QoderLikeVerifierService(VerifierService):
                     errors.append(f"{container_key}[{index}] missing relative_path")
                     continue
                 rel = self._strip_content_prefix(rel.strip())
-                if rel in states:
+                if rel in seen_in_container[container_key]:
                     errors.append(f"duplicate page entry: {rel}")
+                seen_in_container[container_key].add(rel)
                 if not isinstance(state, str) or not state.strip():
                     errors.append(f"{container_key}[{index}] missing quality_state")
                     continue
-                states[rel] = state.strip()
+                normalized_state = state.strip()
+                previous = states.get(rel)
+                if previous is not None and previous != normalized_state:
+                    errors.append(
+                        f"conflicting quality_state for {rel}: {previous!r} vs {normalized_state!r}"
+                    )
+                states[rel] = normalized_state
         return states, errors
 
     def _validate_conflict_report_payload(self, payload: dict[str, Any]) -> list[str]:

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -1,6 +1,7 @@
 """Tests for CLI update command."""
 
 import json
+from pathlib import Path
 from unittest.mock import patch
 
 from typer.testing import CliRunner
@@ -90,3 +91,18 @@ class TestGenerateCommand:
         result = runner.invoke(app, ["generate", "--profile", "qoder-like"])
         # Should parse profile option
         assert "--profile" in result.output or result.exit_code in [0, 1]
+
+    @patch("repo_wiki.cli._run_with_service")
+    def test_generate_qoder_like_output_keeps_runs_layout(self, mock_run):
+        """Documented `--output .repo-agent-eval` must keep the runs/<run> contract."""
+        mock_run.return_value = {"status": "ok"}
+
+        result = runner.invoke(
+            app,
+            ["generate", "--profile", "qoder-like", "--output", ".repo-agent-eval"],
+        )
+        assert result.exit_code == 0
+        eval_profile = mock_run.call_args.kwargs["eval_profile"]
+        assert (
+            Path(eval_profile.root).as_posix().replace("\\", "/").endswith(".repo-agent-eval/runs")
+        )

--- a/tests/test_eval_layout.py
+++ b/tests/test_eval_layout.py
@@ -14,6 +14,7 @@ from repo_wiki.orchestration.eval_layout import (
     generate_manifest,
     get_eval_output_layout_contract,
     get_eval_profile,
+    override_eval_profile_root,
     reject_unsafe_output_root,
     resolve_revision_with_fallback,
     validate_eval_root_safety,
@@ -98,6 +99,23 @@ class TestEvalProfilesRegistry:
     def test_get_unknown_returns_default(self):
         profile = get_eval_profile("nonexistent")
         assert profile.name == "default"
+
+    def test_qoder_like_output_eval_root_keeps_runs_bucket(self):
+        """`--output .repo-agent-eval` is the isolation root, not a replacement for /runs."""
+        profile = override_eval_profile_root(get_eval_profile("qoder-like"), ".repo-agent-eval")
+        assert Path(profile.root).as_posix().replace("\\", "/").endswith(".repo-agent-eval/runs")
+        assert profile.content_subdir == "repowiki/zh/content"
+
+    def test_qoder_like_output_already_runs_does_not_double_nest(self):
+        profile = override_eval_profile_root(
+            get_eval_profile("qoder-like"), ".repo-agent-eval/runs"
+        )
+        assert Path(profile.root).as_posix().replace("\\", "/").endswith(".repo-agent-eval/runs")
+        assert not Path(profile.root).as_posix().replace("\\", "/").endswith("runs/runs")
+
+    def test_default_profile_output_does_not_force_runs(self):
+        profile = override_eval_profile_root(get_eval_profile("default"), ".repo-agent-eval")
+        assert Path(profile.root).as_posix().replace("\\", "/") == ".repo-agent-eval"
 
 
 class TestEvalManifestFile:

--- a/tests/test_generation_quality_artifacts.py
+++ b/tests/test_generation_quality_artifacts.py
@@ -7,6 +7,7 @@ from repo_wiki.core.config import RepoWikiConfig
 from repo_wiki.orchestration.eval_layout import EvalOutputProfile
 from repo_wiki.orchestration.quality_artifacts import build_evidence_index
 from repo_wiki.orchestration.service import RepoWikiService
+from repo_wiki.verifier.qoder_strict_verifier import QoderLikeVerifierService
 
 
 def _write_small_repo(root: Path) -> None:
@@ -78,6 +79,11 @@ def test_qoder_like_generation_emits_quality_registry_and_conflict_artifacts(
 
     assert registry_paths == set(content_pages)
     assert quality_paths == set(content_pages)
+    verifier = QoderLikeVerifierService(run_dir, strict=True)
+    _, quality_path_errors = verifier._collect_artifact_page_quality_states(
+        quality_report, containers=("page_quality", "pages")
+    )
+    assert not any("duplicate page entry" in err for err in quality_path_errors)
     assert all(p["page_id"] and p["stable_page_id"] for p in page_registry["pages"])
     assert {p["generation_mode"] for p in page_registry["pages"]} == {"fallback"}
     assert {p["quality_state"] for p in page_registry["pages"]} == {"DEGRADED"}

--- a/tests/test_qoder_like_verifier.py
+++ b/tests/test_qoder_like_verifier.py
@@ -732,6 +732,26 @@ graph LR
         assert "QODER_PAGE_QUALITY_STATE_MISSING" in result.get("hard_gate_codes", [])
         assert expected_detail in json.dumps(quality_check["details"], ensure_ascii=False)
 
+    def test_quality_report_pages_alias_is_not_a_duplicate_coverage_error(self, tmp_path):
+        """Generate writes page_quality and pages as aliases; that is not missing coverage.
+
+        R1–R11 leftover QODER_PAGE_QUALITY_STATE_MISSING was 'duplicate page entry'
+        because the verifier walked both containers. Same path in both keys with the
+        same state must not trip the HARD gate. True duplicates inside one list still fail.
+        """
+        self._write_release_candidate(tmp_path)
+        meta_dir = tmp_path / "repowiki" / "zh" / "meta"
+        quality_path = meta_dir / "quality-report.json"
+        quality = json.loads(quality_path.read_text(encoding="utf-8"))
+        quality["pages"] = [dict(entry) for entry in quality["page_quality"]]
+        quality_path.write_text(json.dumps(quality), encoding="utf-8")
+
+        result = QoderLikeVerifierService(tmp_path, strict=True).verify(ci=True)
+        quality_check = next(c for c in result["checks"] if c["name"] == "qoder-quality-artifacts")
+
+        assert "QODER_PAGE_QUALITY_STATE_MISSING" not in result.get("hard_gate_codes", [])
+        assert "duplicate page entry" not in json.dumps(quality_check.get("details", {}))
+
     def test_release_candidate_corrupt_conflict_artifact_hard_fails(self, tmp_path):
         self._write_release_candidate(tmp_path)
         (tmp_path / "repowiki" / "zh" / "meta" / "source-docs-conflicts.json").write_text(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
R11 leftover HARD still included `QODER_PAGE_QUALITY_STATE_MISSING` and `QODER_MANIFEST_PATH_INVALID` after generate succeeded. Both were metadata/eval-layout wiring, not LLM quality.

1. **`QODER_PAGE_QUALITY_STATE_MISSING`** — generate writes the same page list under `quality-report.json` `page_quality` *and* `pages`. The verifier walked both containers and treated every page as a duplicate (`duplicate page entry`). That false positive has been in every FastAPI round since R1. Same path in both keys with the same state is now an alias. True duplicates *inside one list* still fail. Conflicting states across aliases still fail.

2. **`QODER_MANIFEST_PATH_INVALID`** — documented `repo-wiki generate --profile qoder-like --output .repo-agent-eval` replaced the qoder-like root (`.repo-agent-eval/runs`) with `.repo-agent-eval`, so runs landed at `.repo-agent-eval/<run>/` instead of `.repo-agent-eval/runs/<run>/`. `--output` is now the isolation root; qoder-like still nests `runs/`. Passing `.repo-agent-eval/runs` does not double-nest.

HARD/SOFT thresholds were not changed. `QODER_PAGE_DUMP`, `QODER_PROSE_TOO_LOW`, coverage 95%, and relevance mismatch are untouched.

Does not merge open docs-only PR #71. Does not start another FastAPI generate.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (adding or updating tests)

## Related Issue
R11 leftover HARD after #70 / PR #71 eval notes. Cycle leftover: make verify pass without relaxing gates.

## Testing Performed
- [x] Ran tests locally: `pytest`
- [x] Ran linting: `ruff check` on changed Python files

Targeted tests covering this fix (red then green):
- `tests/test_qoder_like_verifier.py::TestG005StrictQualityGates::test_quality_report_pages_alias_is_not_a_duplicate_coverage_error`
- existing duplicate-in-one-list parametrize still expects `QODER_PAGE_QUALITY_STATE_MISSING`
- `tests/test_eval_layout.py` qoder-like `--output` keeps `/runs`
- `tests/test_cli_update.py::TestGenerateCommand::test_generate_qoder_like_output_keeps_runs_layout`
- generate quality artifacts no longer collect `duplicate page entry`

Full `pytest`: all tests pass except pre-existing `TestDecisionGateScript.test_strict_rejects_low_overall_score` in this cloud image because `ci/scripts/decision.sh` uses `bc` and `bc` is not installed (`SCORE_COMPARE` falls back to `0`). That test is unrelated to this change; main CI on #70 is green.

## Checklist
- [x] My code follows the project's code style
- [x] I have performed self-review
- [x] I have added tests that prove my fix/feature works
- [x] Gates were not relaxed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c134a08d-f0c4-4040-ad28-1cf2d2f3629e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c134a08d-f0c4-4040-ad28-1cf2d2f3629e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

