### PR TITLE
fix: stop false HARD fails from scanner inventory aliases and generic README claims

### DIFF
--- a/repo_wiki/scanner/docs_scanner.py
+++ b/repo_wiki/scanner/docs_scanner.py
@@ -244,15 +244,33 @@ def _flatten_source_tokens(source_inventory: dict[str, Any]) -> tuple[set[str], 
         for item in bucket:
             if not isinstance(item, dict):
                 continue
-            for field in ("name", "service", "service_id", "handler", "path", "evidence_path"):
+            for field in (
+                "name",
+                "service",
+                "service_id",
+                "handler",
+                "path",
+                "kind",
+                "evidence_path",
+            ):
                 val = item.get(field)
                 if isinstance(val, str) and val.strip():
                     token = val.strip()
                     if "/" in token or "." in token:
                         paths.add(token.lower())
-                    for piece in re.findall(r"[A-Za-z_][A-Za-z0-9_-]{2,}", token):
-                        names.add(piece.lower())
+                    names.update(_iter_name_tokens(token))
     return names, paths
+
+
+def _iter_name_tokens(value: str) -> set[str]:
+    tokens: set[str] = set()
+    for piece in _NAME_TOKEN.findall(value):
+        lowered = piece.lower()
+        tokens.add(lowered)
+        for part in re.split(r"[_-]+", lowered):
+            if len(part) >= 3:
+                tokens.add(part)
+    return tokens
 
 
 def _classify_doc_type(rel: str, text: str) -> str:
@@ -302,6 +320,8 @@ def _specificity(text: str) -> float:
 
 
 _PLAUSIBLE_REL_PATH = re.compile(r"^[A-Za-z0-9_./\\-]+$")
+_NAME_TOKEN = re.compile(r"[A-Za-z_][A-Za-z0-9_-]{2,}")
+_GENERIC_FACT_CLAIM_TOKENS = frozenset({"api", "service", "model", "router"})
 
 
 def _is_plausible_rel_path(value: str) -> bool:
@@ -587,7 +607,9 @@ class DocumentationScanner:
                 [
                     n
                     for n in claim_names
-                    if n not in names and n.endswith(("service", "api", "model"))
+                    if n not in names
+                    and n.endswith(("service", "api", "model"))
+                    and n not in _GENERIC_FACT_CLAIM_TOKENS
                 ]
             )
             freshness = max(0.0, 1.0 - (0.2 * len(stale_refs) + 0.15 * len(conflicting_claims)))

--- a/repo_wiki/verifier/qoder_strict_verifier.py
+++ b/repo_wiki/verifier/qoder_strict_verifier.py
@@ -1755,6 +1755,35 @@ class QoderLikeVerifierService(VerifierService):
                             paths.append(self.root / raw)
         return paths
 
+    _RUNTIME_SERVICE_KINDS = frozenset(
+        {
+            "python_fastapi_app",
+            "python_flask_app",
+            "nodejs_express",
+            "go_main",
+            "spring_component",
+            "docker_compose_service",
+        }
+    )
+
+    @staticmethod
+    def _inventory_lists(data: dict[str, Any], *keys: str) -> list[Any]:
+        items: list[Any] = []
+        for key in keys:
+            value = data.get(key)
+            if isinstance(value, list):
+                items.extend(value)
+        return items
+
+    def _runtime_id_from_service(self, item: dict[str, Any]) -> str | None:
+        kind = item.get("kind")
+        if not isinstance(kind, str) or kind.strip() not in self._RUNTIME_SERVICE_KINDS:
+            return None
+        evidence = item.get("evidence_path")
+        if isinstance(evidence, str) and evidence.strip():
+            return evidence.strip()
+        return kind.strip()
+
     def _load_structured_inventory_sets(self) -> dict[str, Any]:
         meta = None
         payload = self._load_manifest_payload(self.root)
@@ -1778,10 +1807,7 @@ class QoderLikeVerifierService(VerifierService):
                     or data.get("schema_version") == "repo_agent.source_inventory/1.0"
                 ):
                     sources.add(path.name)
-                endpoints = data.get("endpoints", [])
-                if not isinstance(endpoints, list):
-                    endpoints = data.get("api_surfaces", [])
-                for item in endpoints if isinstance(endpoints, list) else []:
+                for item in self._inventory_lists(data, "endpoints", "api_surfaces", "apis"):
                     if (
                         isinstance(item, dict)
                         and isinstance(item.get("method"), str)
@@ -1793,22 +1819,28 @@ class QoderLikeVerifierService(VerifierService):
                         auth = self._endpoint_auth_value(item)
                         if auth is not None:
                             endpoint_auth[api_key] = auth
-                services_payload = data.get("services", [])
-                for item in services_payload if isinstance(services_payload, list) else []:
-                    if isinstance(item, dict):
-                        for key in ("service_id", "service", "name", "display_name"):
-                            value = item.get(key)
-                            if isinstance(value, str):
-                                services.add(value)
-                models_payload = data.get("models", [])
-                if not isinstance(models_payload, list):
-                    models_payload = data.get("data_models", [])
-                for item in models_payload if isinstance(models_payload, list) else []:
+                services_payload = self._inventory_lists(data, "services")
+                for item in services_payload:
+                    if not isinstance(item, dict):
+                        continue
+                    named = False
+                    for key in ("service_id", "service", "name", "display_name"):
+                        value = item.get(key)
+                        if isinstance(value, str) and value.strip():
+                            services.add(value.strip())
+                            named = True
+                    kind = item.get("kind")
+                    if not named and isinstance(kind, str) and kind.strip():
+                        services.add(kind.strip())
+                    runtime_id = self._runtime_id_from_service(item)
+                    if runtime_id:
+                        runtimes.add(runtime_id)
+                for item in self._inventory_lists(data, "models", "data_models"):
                     if isinstance(item, dict):
                         for key in ("model_id", "name", "display_name"):
                             value = item.get(key)
-                            if isinstance(value, str):
-                                models.add(value)
+                            if isinstance(value, str) and value.strip():
+                                models.add(value.strip())
                 for key in ("runtime_entrypoints", "entrypoints", "commands"):
                     runtime_payload = data.get(key, [])
                     for item in runtime_payload if isinstance(runtime_payload, list) else []:

--- a/tests/test_inventory_verify_wiring.py
+++ b/tests/test_inventory_verify_wiring.py
@@ -1,0 +1,193 @@
+"""Generate writes scanner-shaped inventories; verify must read those aliases.
+
+R11 leftover HARD after #72 still included QODER_REQUIRED_INVENTORY_MISSING and
+QODER_UNRESOLVED_FACT_CONFLICT. Generate emits source-inventory.json with
+api_surfaces / data_models / kind-only FastAPI services — not split
+api-inventory.json. README prose like "this service implements the API" was
+flagged as unresolved conflicts. Gates are not relaxed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from repo_wiki.core.config import RepoWikiConfig
+from repo_wiki.orchestration.quality_artifacts import write_generation_conflict_artifacts
+from repo_wiki.scanner.conflict_resolver import resolve_source_docs_conflicts
+from repo_wiki.scanner.docs_scanner import scan_repository_docs_inventory
+from repo_wiki.scanner.multi_runtime_scanner_v3 import scan_repository_source_inventory_v3
+from repo_wiki.verifier.qoder_strict_verifier import (
+    QoderLikeSeverityThreshold,
+    QoderLikeVerifierService,
+)
+
+
+def _write_fastapi_repo(root: Path) -> None:
+    (root / "app").mkdir(parents=True)
+    (root / "app" / "main.py").write_text(
+        "from fastapi import FastAPI\n"
+        "from pydantic import BaseModel\n\n"
+        "app = FastAPI()\n\n"
+        "class User(BaseModel):\n"
+        "    id: str\n\n"
+        "@app.post('/api/users/login')\n"
+        "def login():\n"
+        "    return {}\n\n"
+        "@app.get('/api/articles')\n"
+        "def list_articles():\n"
+        "    return []\n",
+        encoding="utf-8",
+    )
+    (root / "README.rst").write_text(
+        "Conduit RealWorld API\n"
+        "=====================\n\n"
+        "This FastAPI service implements the RealWorld API for users, articles, "
+        "comments, and tags.\n"
+        "The model layer uses Pydantic.\n",
+        encoding="utf-8",
+    )
+
+
+def _write_release_skeleton(run_dir: Path, meta_dir: Path, content_dir: Path) -> None:
+    content_dir.mkdir(parents=True)
+    meta_dir.mkdir(parents=True)
+    (content_dir / "overview.md").write_text(
+        "# Overview\n\n"
+        "## Table of Contents\n"
+        "- [Intro](#intro)\n\n"
+        "## Intro\n\n"
+        "Conduit is the FastAPI RealWorld backend.\n",
+        encoding="utf-8",
+    )
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "version": "1.1",
+                "run_id": "run-inventory-wiring",
+                "readiness_state": "READY",
+                "readiness_reasons": [],
+                "target_dirty": False,
+                "git_fresh": True,
+                "candidate_repowiki_zh_root": str(run_dir / "repowiki" / "zh"),
+                "candidate_content_root": str(content_dir),
+                "candidate_meta_root": str(meta_dir),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_required_inventory_and_conflict_gates_remain_hard() -> None:
+    threshold = QoderLikeSeverityThreshold()
+    assert threshold.is_blocking("QODER_REQUIRED_INVENTORY_MISSING") is True
+    assert threshold.is_blocking("QODER_UNRESOLVED_FACT_CONFLICT") is True
+
+
+def test_scanner_shaped_source_inventory_is_not_missing_required_inventories(
+    tmp_path: Path,
+) -> None:
+    """api_surfaces/data_models/kind-only services must populate required inventories."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_fastapi_repo(repo)
+    run_dir = repo / ".repo-agent-eval" / "runs" / "run-x"
+    meta_dir = run_dir / "repowiki" / "zh" / "meta"
+    content_dir = run_dir / "repowiki" / "zh" / "content"
+    reports_dir = run_dir / "reports"
+    _write_release_skeleton(run_dir, meta_dir, content_dir)
+    reports_dir.mkdir(parents=True)
+
+    cfg = RepoWikiConfig()
+    cfg.project.root = str(repo)
+    cfg.project.exclude = [".repo-agent-eval/**"]
+    write_generation_conflict_artifacts(
+        config=cfg,
+        repo_root=repo,
+        meta_dir=meta_dir,
+        reports_dir=reports_dir,
+        persist_scanner_cache=False,
+    )
+
+    assert not (meta_dir / "api-inventory.json").exists()
+    source = json.loads((meta_dir / "source-inventory.json").read_text(encoding="utf-8"))
+    assert source["api_surfaces"]
+    assert source["data_models"]
+    assert source["services"]
+    assert "endpoints" not in source
+    assert "models" not in source
+    assert not any("service_id" in item for item in source["services"])
+
+    verifier = QoderLikeVerifierService(run_dir, strict=True)
+    inventories = verifier._load_structured_inventory_sets()
+    missing = [
+        name
+        for name in ("sources", "apis", "services", "models", "runtimes")
+        if not inventories[name]
+    ]
+    assert missing == [], missing
+
+    result = verifier.verify(ci=True)
+    assert "QODER_REQUIRED_INVENTORY_MISSING" not in result.get("hard_gate_codes", [])
+
+
+def test_readme_generic_vocabulary_is_not_an_unresolved_fact_conflict(tmp_path: Path) -> None:
+    """Bare 'API'/'service'/'model' and FastAPI framework mentions are not fact conflicts."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_fastapi_repo(repo)
+
+    source = scan_repository_source_inventory_v3(repo, incremental=False)
+    docs = scan_repository_docs_inventory(repo, source, incremental=False, persist_cache=False)
+    readme = next(doc for doc in docs["documents"] if doc["path"] == "README.rst")
+    generic = {"api", "service", "model", "router"}
+    assert generic.isdisjoint({c.lower() for c in readme.get("conflicting_claims") or []})
+
+    report = resolve_source_docs_conflicts(source, docs)
+    deferred_evidence = {
+        str(item).lower()
+        for entry in report["deferred_items"]
+        for item in entry.get("evidence") or []
+    }
+    assert generic.isdisjoint(deferred_evidence)
+    assert "fastapi" not in deferred_evidence
+
+    run_dir = repo / ".repo-agent-eval" / "runs" / "run-x"
+    meta_dir = run_dir / "repowiki" / "zh" / "meta"
+    content_dir = run_dir / "repowiki" / "zh" / "content"
+    reports_dir = run_dir / "reports"
+    _write_release_skeleton(run_dir, meta_dir, content_dir)
+    reports_dir.mkdir(parents=True)
+    cfg = RepoWikiConfig()
+    cfg.project.root = str(repo)
+    cfg.project.exclude = [".repo-agent-eval/**"]
+    write_generation_conflict_artifacts(
+        config=cfg,
+        repo_root=repo,
+        meta_dir=meta_dir,
+        reports_dir=reports_dir,
+        persist_scanner_cache=False,
+    )
+    result = QoderLikeVerifierService(run_dir, strict=True).verify(ci=True)
+    assert "QODER_UNRESOLVED_FACT_CONFLICT" not in result.get("hard_gate_codes", [])
+
+
+def test_named_missing_service_claim_still_unresolved(tmp_path: Path) -> None:
+    """A specific *Service claim that is not in source inventory still defers."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_fastapi_repo(repo)
+    (repo / "docs").mkdir()
+    (repo / "docs" / "roadmap.md").write_text(
+        "# Roadmap\n\nLegacyBillingService will replace the current handlers.\n",
+        encoding="utf-8",
+    )
+    source = scan_repository_source_inventory_v3(repo, incremental=False)
+    docs = scan_repository_docs_inventory(repo, source, incremental=False, persist_cache=False)
+    report = resolve_source_docs_conflicts(source, docs)
+    evidence = [
+        str(item).lower()
+        for entry in report["deferred_items"]
+        for item in entry.get("evidence") or []
+    ]
+    assert any("legacybillingservice" in token for token in evidence)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
R11 leftover HARD still included `QODER_REQUIRED_INVENTORY_MISSING` and `QODER_UNRESOLVED_FACT_CONFLICT` after generate succeeded. Both were inventory/metadata wiring, not LLM quality.

1. **`QODER_REQUIRED_INVENTORY_MISSING`** — generate writes scanner-shaped `source-inventory.json` (`api_surfaces`, `data_models`, kind-only FastAPI `{kind, evidence_path}` services). Verify treated a missing `endpoints`/`models` key as an empty list and never read the scanner aliases, then required `service_id`/`name` and `runtime_entrypoints` that generate never emits. Owner coverage already concatenated `api_surfaces`/`data_models` (R11 owner items=30). Same path now reads those aliases, accepts service `kind` when names are absent, and derives runtimes from scanned app kinds / `evidence_path`. True empty inventories still fail.

2. **`QODER_UNRESOLVED_FACT_CONFLICT`** — docs scanner treated bare README words `service` / `model` / `API` and framework names like `FastAPI` (`endswith("api")`) as conflicting claims, then the resolver deferred them as unresolved. Generic suffix-only tokens are ignored. Source `kind` tokens (e.g. `python_fastapi_app` → `fastapi`) confirm framework mentions. A specific missing claim such as `LegacyBillingService` still defers.

HARD/SOFT thresholds were not changed. Coverage 95%, `QODER_CITATION_RELEVANCE_MISMATCH`, `QODER_PAGE_DUMP`, and `QODER_PROSE_TOO_LOW` are untouched.

Does not merge or edit open docs-only PR #71. Does not stack onto #72. Does not start another FastAPI generate.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (adding or updating tests)

## Related Issue
R11 leftover HARD after #70 / PR #71 eval notes. Cycle leftover: make verify pass without relaxing gates. This PR targets `QODER_REQUIRED_INVENTORY_MISSING` and `QODER_UNRESOLVED_FACT_CONFLICT`.

## Testing Performed
- [x] Ran tests locally: `pytest`
- [x] Ran linting: `ruff check` / `ruff format` on changed Python files

Targeted tests covering this fix (red then green):
- `tests/test_inventory_verify_wiring.py::test_scanner_shaped_source_inventory_is_not_missing_required_inventories`
- `tests/test_inventory_verify_wiring.py::test_readme_generic_vocabulary_is_not_an_unresolved_fact_conflict`
- `tests/test_inventory_verify_wiring.py::test_named_missing_service_claim_still_unresolved`
- `tests/test_inventory_verify_wiring.py::test_required_inventory_and_conflict_gates_remain_hard`

Existing `test_missing_inventories_and_conflict_artifact_fail_closed` and `test_unresolved_fact_conflict_artifact_fails` still expect those HARD codes.

Full `pytest`: all tests pass except pre-existing `TestDecisionGateScript.test_strict_rejects_low_overall_score` in this cloud image because `ci/scripts/decision.sh` uses `bc` and `bc` is not installed (`SCORE_COMPARE` falls back to `0`). That test is unrelated to this change; main CI on #70 is green.

## Checklist
- [x] My code follows the project's code style
- [x] I have performed self-review
- [x] I have added tests that prove my fix/feature works
- [x] Gates were not relaxed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20b2d356-a142-49fa-8557-cd23fe5bfd0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20b2d356-a142-49fa-8557-cd23fe5bfd0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

