### PR TITLE
fix: citation coverage window and FastAPI path relevance false positives

### DIFF
--- a/repo_wiki/orchestration/service.py
+++ b/repo_wiki/orchestration/service.py
@@ -1904,17 +1904,20 @@ class RepoWikiService:
             path = str(endpoint.get("path") or "").strip()
             handler = str(endpoint.get("handler") or "").strip()
             file_path = str(endpoint.get("file_path") or "").strip()
+            line_number = endpoint.get("line_number") or endpoint.get("line_start")
             details = []
             if handler:
                 details.append(f"handler `{handler}`")
             if file_path:
-                line_number = endpoint.get("line_number") or endpoint.get("line_start")
                 location = f"`{file_path}`"
                 if line_number:
                     location += f":{line_number}"
                 details.append(location)
             suffix = f"（{'，'.join(details)}）" if details else ""
-            lines.append(f"- {method} {path}{suffix}")
+            cite = ""
+            if file_path and line_number:
+                cite = f" <cite>{file_path}:{line_number}</cite>"
+            lines.append(f"- {method} {path}{suffix}{cite}")
         return "\n".join(lines)
 
     def _build_truthful_calling_conventions(self, endpoints: list[dict[str, Any]]) -> str:
@@ -1977,7 +1980,12 @@ class RepoWikiService:
                 attrs.append(f"response_type={endpoint.get('response_type')}")
             if endpoint.get("error_codes"):
                 attrs.append(f"error_codes={endpoint.get('error_codes')}")
-            lines.append(f"- {method} {path}: {', '.join(attrs)}")
+            cite = ""
+            file_path = str(endpoint.get("file_path") or "").strip()
+            line_number = endpoint.get("line_number") or endpoint.get("line_start")
+            if file_path and line_number:
+                cite = f" <cite>{file_path}:{line_number}</cite>"
+            lines.append(f"- {method} {path}: {', '.join(attrs)}{cite}")
         return "\n".join(lines)
 
     def _build_mermaid_blocks_from_planner(

--- a/repo_wiki/verifier/citation_fact_coverage.py
+++ b/repo_wiki/verifier/citation_fact_coverage.py
@@ -37,6 +37,7 @@ class ClaimUnit:
     page: str
     line: int
     text: str
+    end_line: int = 0
 
 
 @dataclass(frozen=True)
@@ -75,18 +76,28 @@ def extract_claim_units(markdown: str, *, page: str = "") -> list[ClaimUnit]:
     in_toc = False
     paragraph: list[str] = []
     paragraph_start = 0
+    paragraph_end = 0
 
     def flush() -> None:
-        nonlocal paragraph, paragraph_start
+        nonlocal paragraph, paragraph_start, paragraph_end
         if not paragraph:
             return
         text = " ".join(part.strip() for part in paragraph if part.strip()).strip()
         text = _strip_citations(text)
+        span_end = paragraph_end or paragraph_start
         for sentence in _split_sentences(text):
             if _is_evidence_required(sentence):
-                units.append(ClaimUnit(page=page, line=paragraph_start, text=sentence))
+                units.append(
+                    ClaimUnit(
+                        page=page,
+                        line=paragraph_start,
+                        text=sentence,
+                        end_line=span_end,
+                    )
+                )
         paragraph = []
         paragraph_start = 0
+        paragraph_end = 0
 
     for line_no, line in enumerate(markdown.splitlines(), start=1):
         stripped = line.strip()
@@ -122,18 +133,19 @@ def extract_claim_units(markdown: str, *, page: str = "") -> list[ClaimUnit]:
             item = stripped[2:].strip()
             item = _strip_citations(item)
             if _is_evidence_required(item):
-                units.append(ClaimUnit(page=page, line=line_no, text=item))
+                units.append(ClaimUnit(page=page, line=line_no, text=item, end_line=line_no))
             continue
         if re.match(r"^\d+[.)]\s+", stripped):
             flush()
             item = re.sub(r"^\d+[.)]\s+", "", stripped)
             item = _strip_citations(item)
             if _is_evidence_required(item):
-                units.append(ClaimUnit(page=page, line=line_no, text=item))
+                units.append(ClaimUnit(page=page, line=line_no, text=item, end_line=line_no))
             continue
         if not paragraph:
             paragraph_start = line_no
         paragraph.append(stripped)
+        paragraph_end = line_no
     flush()
     return units
 
@@ -144,15 +156,18 @@ def build_claim_coverage(
     """Compute deterministic claim coverage for a page.
 
     A claim unit is covered when a valid repository citation appears on the same line, the previous
-    line, or the next line. The adjacency rule supports the generator's common pattern of placing a
-    citation immediately after the factual paragraph while keeping coverage auditable.
+    line, the next line, or any line of a wrapped paragraph plus the line immediately after it.
+    The adjacency rule supports the generator's common pattern of placing a citation immediately
+    after the factual paragraph while keeping coverage auditable. Distant footer cites do not cover
+    earlier claims. Uncited claims stay uncovered.
     """
 
     claims = extract_claim_units(markdown, page=page)
     covered = 0
     uncovered: list[dict[str, object]] = []
     for claim in claims:
-        citation_window = {claim.line - 1, claim.line, claim.line + 1}
+        span_end = claim.end_line or claim.line
+        citation_window = set(range(claim.line - 1, span_end + 2))
         if citation_window & valid_repo_citation_lines:
             covered += 1
         else:

--- a/repo_wiki/verifier/qoder_strict_verifier.py
+++ b/repo_wiki/verifier/qoder_strict_verifier.py
@@ -521,6 +521,13 @@ class QoderLikeVerifierService(VerifierService):
                     # Cannot determine expected service, skip
                     continue
 
+                own_keywords = PAGE_SERVICE_MAP[page_service]
+                if any(kw in cite_path_lower for kw in own_keywords):
+                    # Nested real-world paths such as app/api/routes/authentication.py
+                    # match both "api"/"route" and "auth". That is the auth API, not a
+                    # high-confidence wrong-service bind.
+                    continue
+
                 # Check if citation path contains evidence of wrong service
                 wrong_service_evidence = False
                 other_services = [k for k in PAGE_SERVICE_MAP if k != page_service]
@@ -529,6 +536,7 @@ class QoderLikeVerifierService(VerifierService):
                     other_keywords = PAGE_SERVICE_MAP[other_service]
                     # High confidence mismatch: page name suggests service A
                     # but citation path contains strong indicators of service B
+                    # and none of service A's own keywords.
                     if any(kw in cite_path_lower for kw in other_keywords):
                         # Make sure it's not shared infrastructure
                         if not is_shared:

--- a/tests/test_citation_coverage_relevance_wiring.py
+++ b/tests/test_citation_coverage_relevance_wiring.py
@@ -1,0 +1,220 @@
+"""R11 leftover HARD: citation coverage window and relevance path overlap.
+
+QODER_CITATION_FACT_COVERAGE_LOW and QODER_CITATION_RELEVANCE_MISMATCH were still
+open after generate succeeded with 0 invalid cites. These tests pin the wiring bugs:
+
+1. Coverage uses paragraph start only, so a cite immediately after a wrapped
+   factual paragraph is not counted (the adjacency docstring already describes
+   that generator pattern).
+2. Relevance treats overlapping taxonomy keywords in real paths such as
+   app/api/routes/authentication.py as a wrong-service bind.
+3. Page-contract API grouping has file:line evidence but writes backticks
+   instead of <cite>, so verifier-required claims are born uncovered.
+
+Gates stay HARD. The 95% coverage threshold is not lowered. Uncited claims stay
+uncovered. True wrong-service binds still fail.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from repo_wiki.core.config import RepoWikiConfig
+from repo_wiki.generator.composer import ComposerContext
+from repo_wiki.orchestration.service import RepoWikiService
+from repo_wiki.planner.schema import WikiPagePlan, WikiTaxonomyCategory
+from repo_wiki.verifier.citation_fact_coverage import (
+    build_claim_coverage,
+    extract_citation_refs_with_lines,
+)
+from repo_wiki.verifier.qoder_strict_verifier import (
+    QoderLikeSeverityThreshold,
+    QoderLikeVerifierService,
+)
+
+
+def _coverage(markdown: str, *, valid_lines: set[int] | None = None) -> dict[str, object]:
+    if valid_lines is None:
+        valid_lines = {ref.line for ref in extract_citation_refs_with_lines(markdown)}
+    return build_claim_coverage(markdown, page="overview.md", valid_repo_citation_lines=valid_lines)
+
+
+def test_wrapped_paragraph_with_trailing_cite_is_covered() -> None:
+    """Cite immediately after a wrapped factual paragraph must count as covered."""
+    markdown = """# Project Overview
+
+The UserService implements authentication for Conduit users
+and provides JWT token validation for GET /api/users login.
+<cite>app/api/routes/authentication.py:1-20</cite>
+"""
+    result = _coverage(markdown)
+    assert int(result["total"]) >= 1
+    assert result["uncovered"] == []
+    assert float(result["ratio"]) == 1.0
+
+
+def test_uncited_claim_is_still_uncovered() -> None:
+    """Do not count unverifiable claims as covered."""
+    markdown = """# Project Overview
+
+The UserService implements authentication for Conduit users
+and provides JWT token validation for GET /api/users login.
+
+A later section with no nearby citation.
+"""
+    result = _coverage(markdown)
+    assert int(result["total"]) >= 1
+    assert int(result["covered"]) == 0
+    assert float(result["ratio"]) == 0.0
+    assert result["uncovered"]
+
+
+def test_single_line_claim_still_requires_adjacent_cite() -> None:
+    """A cite far below a one-line claim is not coverage."""
+    markdown = """# Project Overview
+
+The UserService implements authentication for GET /api/users.
+
+## Later
+
+Filler paragraph without factual signals.
+
+<cite>app/api/routes/authentication.py:1-20</cite>
+"""
+    result = _coverage(markdown)
+    assert int(result["total"]) >= 1
+    assert any("UserService" in str(item.get("text", "")) for item in result["uncovered"])
+    assert float(result["ratio"]) < 1.0
+
+
+def test_fastapi_authentication_route_cite_is_not_relevance_mismatch(tmp_path: Path) -> None:
+    """app/api/routes/authentication.py is the auth API, not a wrong-service bind."""
+    content_dir = tmp_path / "content"
+    content_dir.mkdir()
+    (content_dir / "authentication-api.md").write_text(
+        """# Authentication API
+
+## Table of Contents
+- [Login](#login)
+
+## Login
+
+POST /api/users/login authenticates Conduit users.
+
+<cite>app/api/routes/authentication.py:1-20</cite>
+""",
+        encoding="utf-8",
+    )
+
+    result = QoderLikeVerifierService(tmp_path, strict=True).verify(ci=True)
+    assert "QODER_CITATION_RELEVANCE_MISMATCH" not in result.get("hard_gate_codes", [])
+    relevance = next(c for c in result["checks"] if c["name"] == "qoder-citation-relevance")
+    assert relevance["status"] in {"PASS", "WARN", "SKIP"}
+
+
+def test_api_page_citing_authentication_route_is_not_relevance_mismatch(tmp_path: Path) -> None:
+    """API pages citing app/api/routes/authentication.py are documenting that API."""
+    content_dir = tmp_path / "content"
+    content_dir.mkdir()
+    (content_dir / "api-reference.md").write_text(
+        """# API Reference
+
+## Endpoints
+
+POST /api/users/login is the Conduit login endpoint.
+
+<cite>app/api/routes/authentication.py:10-40</cite>
+""",
+        encoding="utf-8",
+    )
+
+    result = QoderLikeVerifierService(tmp_path, strict=True).verify(ci=True)
+    assert "QODER_CITATION_RELEVANCE_MISMATCH" not in result.get("hard_gate_codes", [])
+
+
+def test_billing_page_citing_auth_only_path_still_relevance_mismatch(tmp_path: Path) -> None:
+    """True wrong-service binds stay HARD. Do not relax the gate."""
+    content_dir = tmp_path / "content"
+    content_dir.mkdir()
+    (content_dir / "billing-service.md").write_text(
+        """# Billing Service
+
+The billing service handles payments and subscriptions.
+
+<cite>src/auth/session.py:1</cite>
+""",
+        encoding="utf-8",
+    )
+
+    result = QoderLikeVerifierService(tmp_path, strict=True).verify(ci=True)
+    assert "QODER_CITATION_RELEVANCE_MISMATCH" in result.get("hard_gate_codes", [])
+    relevance = next(c for c in result["checks"] if c["name"] == "qoder-citation-relevance")
+    assert relevance["status"] == "FAIL"
+    assert relevance["reason_code"] == "QODER_CITATION_RELEVANCE_MISMATCH"
+    assert relevance["gate_type"] == "HARD"
+
+
+def test_evidence_backed_api_group_emits_cite_for_endpoint_claim(tmp_path: Path) -> None:
+    """Page contract already has file:line; emit <cite> so the GET claim is covered."""
+    cfg = RepoWikiConfig()
+    cfg.project.root = str(tmp_path)
+    service = RepoWikiService(cfg)
+    page = WikiPagePlan(
+        page_id="inventory-api",
+        title="Inventory API",
+        category=WikiTaxonomyCategory.API_REFERENCE,
+        output_path="docs/pages/api/inventory-api.md",
+    )
+    (tmp_path / "src" / "inventory").mkdir(parents=True)
+    (tmp_path / "src" / "inventory" / "api.py").write_text(
+        "\n".join(f"line {i}" for i in range(1, 50)),
+        encoding="utf-8",
+    )
+    rendered = service._enforce_qoder_page_contract(
+        page=page,
+        markdown="# Inventory API\n\n## 简介\n\n短说明。",
+        binding=None,
+        add_mermaid=False,
+        composition_context=ComposerContext(
+            repository_name="repo",
+            primary_language="python",
+            framework="fastapi",
+            repository_root=str(tmp_path),
+            endpoints=[
+                {
+                    "method": "GET",
+                    "path": "/inventory/items",
+                    "module": "inventory",
+                    "handler": "list_items",
+                    "file_path": "src/inventory/api.py",
+                    "line_number": 42,
+                    "auth_type": "api-key",
+                }
+            ],
+        ),
+    )
+
+    assert "GET /inventory/items" in rendered
+    assert "<cite>src/inventory/api.py:42</cite>" in rendered
+
+    coverage = build_claim_coverage(
+        rendered,
+        page="inventory-api.md",
+        valid_repo_citation_lines={ref.line for ref in extract_citation_refs_with_lines(rendered)},
+    )
+    uncovered_text = " ".join(str(item.get("text", "")) for item in coverage["uncovered"])
+    assert "GET /inventory/items" not in uncovered_text
+    assert int(coverage["covered"]) >= 1
+
+
+def test_coverage_and_relevance_gates_remain_hard() -> None:
+    """Do not relax leftover citation HARD codes or the 95% coverage floor."""
+    threshold = QoderLikeSeverityThreshold()
+    assert "QODER_CITATION_FACT_COVERAGE_LOW" in threshold.STRICT_HARD_CODES
+    assert "QODER_CITATION_RELEVANCE_MISMATCH" in threshold.STRICT_HARD_CODES
+
+    from repo_wiki.verifier import qoder_strict_verifier as verifier_mod
+
+    source = Path(verifier_mod.__file__).read_text(encoding="utf-8")
+    assert "if ratio < 0.95:" in source
+    assert 'reason_code="QODER_CITATION_FACT_COVERAGE_LOW"' in source


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

R11 leftover HARD still included `QODER_CITATION_FACT_COVERAGE_LOW` (50.87% vs 95%) and `QODER_CITATION_RELEVANCE_MISMATCH` after generate succeeded with **0 invalid cites**. Both were citation/claim-extraction wiring, not “the model cited too little.”

This PR targets **`QODER_CITATION_FACT_COVERAGE_LOW`** and **`QODER_CITATION_RELEVANCE_MISMATCH`**.

1. **`QODER_CITATION_FACT_COVERAGE_LOW`** — coverage used `paragraph_start` only, so a cite immediately after a wrapped factual paragraph was uncovered. The adjacency docstring already describes that generator pattern. The window now spans the wrapped paragraph plus the following line. Distant footer cites still do not cover earlier claims. Uncited claims stay uncovered.

2. **Page-contract API grouping** — generate already had `file_path` + `line_number` for evidence-backed endpoints but wrote backtick paths. Those `GET /…` list items are evidence-required claims born without `<cite>`. Same-line `<cite>path:line</cite>` is now emitted when line evidence exists. Schema summary lines get the same cite when file+line exist.

3. **`QODER_CITATION_RELEVANCE_MISMATCH`** — FastAPI paths such as `app/api/routes/authentication.py` match both `api`/`route` and `auth`. That is the auth API, not a high-confidence wrong-service bind. If the path already matches the page’s own service keywords, it is not a mismatch. Billing pages citing `src/auth/session.py` still fail HARD.

**Gates were not relaxed.** `QODER_CITATION_FACT_COVERAGE_LOW` stays HARD at **95%**. `QODER_CITATION_RELEVANCE_MISMATCH` stays HARD. Unverifiable claims are not counted as covered.

Does not merge or edit open PRs #71 (docs-only R11 eval), #72 (quality-report aliases + `/runs`), #73 (scanner inventory aliases), or #74 (write-floor dump/prose). Starts from main. Does not start another FastAPI generate.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (adding or updating tests)

## Related Issue
R11 leftover HARD after #70 / PR #71 eval notes. Cycle leftover: make verify pass without relaxing gates. This PR targets `QODER_CITATION_FACT_COVERAGE_LOW` and `QODER_CITATION_RELEVANCE_MISMATCH`.

## Testing Performed
- [x] Ran tests locally: `pytest`
- [x] Ran linting: `ruff check` / `ruff format` on changed Python files

Targeted tests covering this fix (red then green):
- `tests/test_citation_coverage_relevance_wiring.py::test_wrapped_paragraph_with_trailing_cite_is_covered`
- `tests/test_citation_coverage_relevance_wiring.py::test_uncited_claim_is_still_uncovered`
- `tests/test_citation_coverage_relevance_wiring.py::test_single_line_claim_still_requires_adjacent_cite`
- `tests/test_citation_coverage_relevance_wiring.py::test_fastapi_authentication_route_cite_is_not_relevance_mismatch`
- `tests/test_citation_coverage_relevance_wiring.py::test_api_page_citing_authentication_route_is_not_relevance_mismatch`
- `tests/test_citation_coverage_relevance_wiring.py::test_billing_page_citing_auth_only_path_still_relevance_mismatch`
- `tests/test_citation_coverage_relevance_wiring.py::test_evidence_backed_api_group_emits_cite_for_endpoint_claim`
- `tests/test_citation_coverage_relevance_wiring.py::test_coverage_and_relevance_gates_remain_hard`

Existing `test_claim_citation_coverage_94_fails_and_95_passes` still requires 95%. Existing billing-citing-auth relevance test still expects HARD fail.

Full `pytest`: 2348 passed, 8 skipped. The only failure is pre-existing `TestDecisionGateScript.test_strict_rejects_low_overall_score` in this cloud image because `ci/scripts/decision.sh` uses `bc` and `bc` is not installed (`SCORE_COMPARE` falls back to `0`). That test is unrelated to this change; main CI on #70 is green.

## Checklist
- [x] My code follows the project's code style
- [x] I have performed self-review
- [x] I have added tests that prove my fix/feature works
- [x] Gates were not relaxed
- [x] 95% citation coverage threshold was not changed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79e00e13-2bcc-4e9c-bad0-81f78c43ee83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79e00e13-2bcc-4e9c-bad0-81f78c43ee83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

