### PR TITLE
docs: FastAPI RealWorld round-14 eval after #85

### DIFF
--- a/docs/eval/2026-08-13-fastapi-realworld-wrap.md
+++ b/docs/eval/2026-08-13-fastapi-realworld-wrap.md
@@ -1,6 +1,6 @@
 # FastAPI RealWorld wiki 质量对照 wrap
 
-**日期：** 2026-08-13–2026-08-14 CST  
+**日期：** 2026-08-13–2026-08-17 CST  
 **对照：** nsidnev/fastapi-realworld-example-app `029eb778` × MiniMax-M3  
 **CLI：** r1 `9cadf85`（#40）→ r2 `c2407979`（#42 空 content 重试 + #43 FastAPI 扫描）→ r3 `a3d58b4`（#45 导入 router 前缀拼接）→ r4 `9328896`（#50；含 #48 `api_prefix` + #49 circuit-break）→ r5 `8912c89`（#52 README/身份优先于 init stub 与 eval notes）→ r6 `b0a06f4`（#54 README.rst 解析 + pyproject fallback）→ r7 `2e3a3f0`（#56 identity.description 流入 overview）→ r8 `05bb3b8`（#58 去掉 citation `file:` 前缀）
 
@@ -13,7 +13,8 @@
 第七轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round7.md`。  
 第八轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round8.md`。  
 第九轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round9.md`。  
-第十轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round10.md`。
+第十轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round10.md`。  
+第十四轮评测见 `docs/eval/2026-08-17-fastapi-realworld-round14.md`。
 
 ## r1 vs r2
 
@@ -229,4 +230,31 @@ verify JSON：`docs/eval/2026-08-14-fastapi-realworld-round8-verify.json`。
 - taxonomy 幻觉页；泄漏 `<think>` 89 页。
 - coverage 42.28% 仍 << 95%；eval-layout HARD；API mermaid 缺 9 / ER 缺 5。
 - r8 verify：**12 HARD / 0 SOFT**（未放宽）。不要松阈值。
+
+## r13 vs r14
+
+评测正文：`docs/eval/2026-08-17-fastapi-realworld-round14.md`。  
+verify JSON：`docs/eval/2026-08-17-fastapi-realworld-round14-verify.json`。
+
+真实 MiniMax-M3 run `r14-2026-08-17`。CLI `278164e` = r13 栈 #72+#73+#74+#75+#82+#83 @ `3053586` + #85 `550782c`（本地 `r14-eval-local`；两处 keep-both；**未推送、未进 main**）。未叠到 #84。R13 正文在 #84。
+
+| 项 | r13 | **r14** |
+|---|---|---|
+| CLI | `3053586` / #72+#73+#74+#75+#82+#83（未进 main） | **`278164e`** / r13 栈 + #85（未进 main） |
+| generate | — | **EXIT=0；81/81；cache 0/81** |
+| LLM PASS / DEGRADED | — | **68 / 13** |
+| llm_call_count / tokens | — | **81 / 312531** |
+| fallback | — | **13**（全部 insufficient prose） |
+| 529 / circuit-break | — | **0 / false** |
+| MiniMax 1004 | — | **0** |
+| coverage | 65.08%；门仍是 95% | **64.44%**（928/1440）仍 << 95% |
+| HARD / SOFT | 7 / 0 | **5 / 0**（未放宽） |
+| Overview Conduit | HIT（两张 overview 页） | **HIT**（两张 overview 页） |
+| owner missing | 0 | **0** |
+| conflict（GitHub badges） | HARD | **PASS** |
+| API aggregation | HARD | **PASS 6/6** |
+| mermaid entity shape | HARD 证据 | **gone** |
+| #85 leftover code | `CRITICAL_FALSE_FACT`（mermaid entity） | **MISS**（仍 HARD；1 claim `DELETE /api/articles`，不是 R13 mermaid entity） |
+
+不要声称 #85 全部清掉 HARD。HARD 计数 7→5。不要松 HARD/SOFT。不要把这些产品 PR 合进 main。
 

--- a/docs/eval/2026-08-17-fastapi-realworld-round14-verify.json
+++ b/docs/eval/2026-08-17-fastapi-realworld-round14-verify.json
@@ -1,0 +1,69 @@
+{
+  "run_id": "r14-2026-08-17",
+  "cli": "278164e",
+  "cli_full": "278164eff0e1de710d960356eaac95156ea8f7ad",
+  "cli_branch": "r14-eval-local",
+  "base_main": "1fe6840",
+  "prs": ["#72", "#73", "#74", "#75", "#82", "#83", "#85"],
+  "stacked_eval": "r13 stack #72 #73 #74 #75 #82 #83 @ 3053586 + #85 550782c onto main 1fe6840; two keep-both conflict resolutions; not pushed",
+  "pr85_hit": "MIXED",
+  "grade": "FAIL",
+  "hard_fail": 5,
+  "soft_fail": 0,
+  "hard_codes": [
+    "QODER_PAGE_QUALITY_STATE_DEGRADED",
+    "QODER_CRITICAL_FALSE_FACT",
+    "QODER_CITATION_FACT_COVERAGE_LOW",
+    "QODER_CITATION_RELEVANCE_MISMATCH",
+    "QODER_DIRTY_WORKTREE"
+  ],
+  "pages": {
+    "planned": 81,
+    "written": 81,
+    "pass": 68,
+    "degraded": 13,
+    "fallback": 13,
+    "llm_call_count": 81
+  },
+  "fallback_breakdown": {
+    "insufficient_prose": 13
+  },
+  "http_529": 0,
+  "minimax_1004": 0,
+  "circuit_break_tripped": false,
+  "provider_failure_count": 0,
+  "empty_content": 0,
+  "cache_hits": 0,
+  "cache_misses": 81,
+  "actual_tokens": 312531,
+  "timeout_s": 180,
+  "host": "api.minimaxi.com",
+  "owner_check": "PASS",
+  "owner_missing": 0,
+  "overview_conduit": true,
+  "overview_conduit_both_pages": true,
+  "claim_coverage_percent": "64.44%",
+  "claim_coverage": "928/1440",
+  "claim_coverage_gate_percent": "95%",
+  "relevance_mismatch": {"message": 27, "details": 20},
+  "api_aggregation": {"result": "PASS", "score": "6/6"},
+  "conflict": {
+    "code": "QODER_UNRESOLVED_FACT_CONFLICT",
+    "result": "PASS",
+    "r13_shape": "GitHub badges"
+  },
+  "critical_false_fact": {
+    "shape": "DELETE /api/articles",
+    "not_r13_shape": "mermaid entity",
+    "claim_count": 1,
+    "real_route": "DELETE /api/articles/{slug}",
+    "pages": [
+      "API参考/核心服务API/API API.md"
+    ]
+  },
+  "generate_exit": 0,
+  "verify_exit": 1,
+  "generate_wall": "13m13s",
+  "verify_wall": "4s",
+  "note": "Real MiniMax-M3 run r14-2026-08-17. CLI 278164e = r13 stack #72 #73 #74 #75 #82 #83 @ 3053586 + #85 550782c (r14-eval-local; two keep-both; not pushed). HARD 5 / SOFT 0 (dropped vs R13 HARD 7). HIT vs R13 leftovers: UNRESOLVED_FACT_CONFLICT (GitHub badges) PASS, API_AGGREGATION_LOW PASS 6/6, mermaid entity shape gone, owner 0 missing, dump/prose leftover codes PASS, Overview Conduit both pages. MISS: CRITICAL_FALSE_FACT (new shape DELETE /api/articles), degraded (13 fallback), coverage 64.44% still << 95%, relevance, dirty worktree. Do not claim #85 fully cleared HARD. HARD count dropped 7→5. Gates not relaxed."
+}

--- a/docs/eval/2026-08-17-fastapi-realworld-round14.md
+++ b/docs/eval/2026-08-17-fastapi-realworld-round14.md
@@ -1,0 +1,83 @@
+# FastAPI RealWorld 对照 Wiki 第十四轮评测
+
+**对照仓：** nsidnev/fastapi-realworld-example-app `029eb7781c60d5f563ee8990a0cbfb79b244538c`
+**CLI：** `278164eff0e1de710d960356eaac95156ea8f7ad`（本地分支 `r14-eval-local`；r13 栈 #72–#75+#82+#83 @ `3053586` + #85 `550782c`；两处 keep-both 冲突解决，仅用于叠评测；**未推送**）
+**时间：** 2026-08-17（generate wall **13m13s**；verify wall 4s）
+**run：** r14-2026-08-17
+**模型：** MiniMax-M3，host `api.minimaxi.com`，timeout 180，cache 0/81
+**verify JSON：** `docs/eval/2026-08-17-fastapi-realworld-round14-verify.json`
+
+本轮是真实 MiniMax generate，不是 MockLLM。
+
+第十三轮评测见 `docs/eval/2026-08-17-fastapi-realworld-round13.md`（#84，docs-only）。  
+对照 wrap 见 `docs/eval/2026-08-13-fastapi-realworld-wrap.md`。
+
+本 PR 只含评测文档。未改产品代码。未编辑 #71–#85。未把 #72–#75+#82+#83+#85 推进 main。未叠到 #84。门槛未放宽。不要声称 #85 全部清掉 HARD。HARD 计数 7→5。
+
+## Hits / Misses（相对 R13 leftover HARD）
+
+| leftover code | R13 | **R14** | |
+|---|---|---|---|
+| `QODER_PAGE_QUALITY_STATE_DEGRADED` | HARD | FAIL（13 fallback） | **MISS** |
+| `QODER_UNRESOLVED_FACT_CONFLICT` | FAIL（GitHub badges） | **PASS** | **HIT** |
+| `QODER_CRITICAL_FALSE_FACT` | FAIL（mermaid entity） | FAIL（1 claim `DELETE /api/articles`，页 `API参考/核心服务API/API API.md`；真实路由是 `DELETE /api/articles/{slug}`），**不是** R13 mermaid entity | **MISS**（新形态） |
+| `QODER_CITATION_FACT_COVERAGE_LOW` | FAIL **65.08%**；门仍是 95% | FAIL **64.44%**（928/1440）；门仍是 95% | **MISS** |
+| `QODER_CITATION_RELEVANCE_MISMATCH` | FAIL | FAIL（message 27 / details 20） | **MISS** |
+| `QODER_API_AGGREGATION_LOW` | FAIL | **PASS 6/6** | **HIT** |
+| `QODER_DIRTY_WORKTREE` | FAIL（untracked `.repo-agent-eval/`） | FAIL（untracked `.repo-agent-eval/`） | **MISS** |
+| mermaid entity shape | HARD 证据 | **gone** | **HIT** |
+| owner missing | 0 | **0** | **HIT** |
+| dump / prose leftover codes | PASS | **PASS** | **HIT** |
+
+Overview Conduit：**HIT**（两张 overview 页）。
+
+#85 目标含 mermaid entity、GitHub badges、API filename HARD。本轮 conflict **HIT**、aggregation **HIT 6/6**、mermaid entity shape **gone**。`QODER_CRITICAL_FALSE_FACT` 仍 HARD，证据换成 `DELETE /api/articles`（缺 `{slug}`）。不要声称 #85 全部清掉 HARD。HARD 7→5，计数下降但未清场。
+
+## Generate
+
+GENERATE_EXIT=0。Cold cache：cache_hits=0，cache_misses=81。
+
+| 项 | R13 | **R14** |
+|---|---|---|
+| planned / written | 81 / 81 | **81 / 81** |
+| LLM PASS / DEGRADED | — | **68 / 13** |
+| llm_call_count / tokens | — | **81 / 312531** |
+| fallback | — | **13**（全部 insufficient prose） |
+| 529 / circuit-break | — | **0 / false** |
+| MiniMax 1004 | — | **0** |
+| provider_failure_count | — | **0** |
+| empty-content | — | **0** |
+| Overview Conduit | HIT（两张 overview 页） | **HIT**（两张 overview 页） |
+| wall | — | **13m13s** generate + 4s verify |
+
+表中 R13 生成细项未在本评测任务里给出，不补造。
+
+## Compare
+
+| | R13 | **R14** |
+|---|---|---|
+| CLI | `3053586` / #72+#73+#74+#75+#82+#83（本地 `r13-eval-local`；未推送；未进 main） | **`278164e`** / r13 栈 + #85 `550782c`（本地 `r14-eval-local`；未推送；未进 main） |
+| coverage | 65.08%；门仍是 95% | **64.44%**（928/1440）仍 << 95% |
+| HARD / SOFT | 7 / 0 | **5 / 0**（未放宽） |
+| owner missing | 0 | **0** |
+| API aggregation | HARD | **PASS 6/6** |
+| conflict（GitHub badges） | HARD | **PASS** |
+| false-fact | mermaid entity | **新形态** `DELETE /api/articles`（1 claim） |
+
+## Verify
+
+VERIFY_EXIT=1 / FAIL。HARD 5 / SOFT 0。Gates **not** relaxed。95% coverage 门未改。
+
+Leftover HARD：
+
+1. `QODER_PAGE_QUALITY_STATE_DEGRADED`（13 fallback）
+2. `QODER_CRITICAL_FALSE_FACT` — 1 claim `DELETE /api/articles`，页 `API参考/核心服务API/API API.md`（**不是** R13 mermaid entity）。真实路由是 `DELETE /api/articles/{slug}`
+3. `QODER_CITATION_FACT_COVERAGE_LOW` 64.44%（928/1440）vs R13 65.08%；门仍是 95%
+4. `QODER_CITATION_RELEVANCE_MISMATCH`（message 27 / details 20）
+5. `QODER_DIRTY_WORKTREE`（untracked `.repo-agent-eval/`）
+
+SOFT none。
+
+不要把 HARD 7→5 解读成 #85 清场，也不要解读成门槛放松。
+
+不要在本评测 PR 里改产品代码。不要把 #72–#75+#82+#83+#85 合进 main。

--- a/docs/plans/current-roadmap.md
+++ b/docs/plans/current-roadmap.md
@@ -22,7 +22,7 @@
 
 - qoder-like 隔离输出与 HARD/SOFT 门禁（不放宽）
 - FastAPI 对照闭环里已修：路由前缀 / `settings.api_prefix`、产品身份（README/pyproject → overview）、`file:` 引用、mounted `/api` owner 绑定（#43–#59）
-- Codex plugin #50；R8 评测见 `docs/eval/2026-08-14-fastapi-realworld-round8.md`；R9 评测见 `docs/eval/2026-08-14-fastapi-realworld-round9.md`；R10 评测见 `docs/eval/2026-08-14-fastapi-realworld-round10.md`
+- Codex plugin #50；R8 评测见 `docs/eval/2026-08-14-fastapi-realworld-round8.md`；R9 评测见 `docs/eval/2026-08-14-fastapi-realworld-round9.md`；R10 评测见 `docs/eval/2026-08-14-fastapi-realworld-round10.md`；R14 评测见 `docs/eval/2026-08-17-fastapi-realworld-round14.md`
 
 ## 本周期（先把单库 Wiki 做准）
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
R13 leftover HARD after real MiniMax-M3 `r13-2026-08-17` / #84. This PR records **real MiniMax-M3 R14** after locally stacking #85 `550782c` onto the r13 CLI (`#72–#75+#82+#83` @ `3053586`; CLI `278164eff0e1de710d960356eaac95156ea8f7ad`, branch `r14-eval-local`, two keep-both conflict resolutions, not pushed). Contrast nsidnev/fastapi-realworld-example-app `029eb778`.

GENERATE_EXIT=0. VERIFY_EXIT=1. HARD **5** / SOFT **0** (dropped vs R13 HARD 7). Coverage **64.44%** (928/1440) vs R13 65.08%; gate still 95%. 81/81 pages, 68 PASS / 13 DEGRADED. Cache 0/81. llm_call_count=81, actual_tokens=312531. 13 fallback (all insufficient prose). provider_failure_count=0, circuit-break false, empty-content 0, 529 0, MiniMax 1004 0. Overview Conduit HIT on both overview pages. Generate wall 13m13s; verify 4s.

| leftover code | vs R13 | |
|---|---|---|
| `QODER_PAGE_QUALITY_STATE_DEGRADED` | FAIL (13 fallback) | **MISS** |
| `QODER_UNRESOLVED_FACT_CONFLICT` | PASS (GitHub badges) | **HIT** |
| `QODER_CRITICAL_FALSE_FACT` | FAIL; 1 claim `DELETE /api/articles` on `API参考/核心服务API/API API.md`; real route is `DELETE /api/articles/{slug}`; not R13 mermaid entity | **MISS** (new shape) |
| `QODER_CITATION_FACT_COVERAGE_LOW` | FAIL 64.44% (R13 65.08%) | **MISS** |
| `QODER_CITATION_RELEVANCE_MISMATCH` | FAIL (message 27 / details 20) | **MISS** |
| `QODER_API_AGGREGATION_LOW` | PASS 6/6 | **HIT** |
| `QODER_DIRTY_WORKTREE` | FAIL (untracked `.repo-agent-eval/`) | **MISS** |
| mermaid entity / owner 0 / dump+prose leftover codes | PASS | **HIT** |

Do not claim #85 fully cleared HARD. HARD count dropped 7→5.

## Type of Change
- [x] Documentation update (typos, docs, etc.)

Docs only. No product-code change. Gates not relaxed. Starts from main. Does not stack onto #84. Does not edit #71–#85. Do not merge product PRs via this PR. Do not merge until reviewed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d2a080d-04fa-4a99-8c18-dd83408c2395?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d2a080d-04fa-4a99-8c18-dd83408c2395&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

