### PR TITLE
docs: FastAPI RealWorld round-15 eval after #87

### DIFF
--- a/docs/eval/2026-08-13-fastapi-realworld-wrap.md
+++ b/docs/eval/2026-08-13-fastapi-realworld-wrap.md
@@ -250,8 +250,9 @@ verify JSON：`docs/eval/2026-08-17-fastapi-realworld-round15-verify.json`。
 | coverage | 64.44%（928/1440）；门仍是 95% | **67.02%**（951/1419）仍 << 95% |
 | HARD / SOFT | 5 / 0 | **4 / 0**（未放宽） |
 | owner missing | 0 | **0** |
+| Overview Conduit | HIT（两张 overview 页） | **HIT**（两张 overview 页） |
 | conflict（GitHub badges） | PASS | **PASS** |
-| API aggregation | PASS | **PASS** |
+| API aggregation | PASS 6/6 | **PASS 6/6** |
 | #87 leftover code | `CRITICAL_FALSE_FACT`（`DELETE /api/articles`） | **HIT**（PASS；claim_count 0） |
 
 不要声称 leftover HARD 已清。HARD 计数 5→4。不要松 HARD/SOFT。不要把这些产品 PR 合进 main。

--- a/docs/eval/2026-08-13-fastapi-realworld-wrap.md
+++ b/docs/eval/2026-08-13-fastapi-realworld-wrap.md
@@ -1,6 +1,6 @@
 # FastAPI RealWorld wiki 质量对照 wrap
 
-**日期：** 2026-08-13–2026-08-14 CST  
+**日期：** 2026-08-13–2026-08-17 CST  
 **对照：** nsidnev/fastapi-realworld-example-app `029eb778` × MiniMax-M3  
 **CLI：** r1 `9cadf85`（#40）→ r2 `c2407979`（#42 空 content 重试 + #43 FastAPI 扫描）→ r3 `a3d58b4`（#45 导入 router 前缀拼接）→ r4 `9328896`（#50；含 #48 `api_prefix` + #49 circuit-break）→ r5 `8912c89`（#52 README/身份优先于 init stub 与 eval notes）→ r6 `b0a06f4`（#54 README.rst 解析 + pyproject fallback）→ r7 `2e3a3f0`（#56 identity.description 流入 overview）→ r8 `05bb3b8`（#58 去掉 citation `file:` 前缀）
 
@@ -13,7 +13,8 @@
 第七轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round7.md`。  
 第八轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round8.md`。  
 第九轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round9.md`。  
-第十轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round10.md`。
+第十轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round10.md`。  
+第十五轮评测见 `docs/eval/2026-08-17-fastapi-realworld-round15.md`。
 
 ## r1 vs r2
 
@@ -229,4 +230,29 @@ verify JSON：`docs/eval/2026-08-14-fastapi-realworld-round8-verify.json`。
 - taxonomy 幻觉页；泄漏 `<think>` 89 页。
 - coverage 42.28% 仍 << 95%；eval-layout HARD；API mermaid 缺 9 / ER 缺 5。
 - r8 verify：**12 HARD / 0 SOFT**（未放宽）。不要松阈值。
+
+## r14 vs r15
+
+评测正文：`docs/eval/2026-08-17-fastapi-realworld-round15.md`。  
+verify JSON：`docs/eval/2026-08-17-fastapi-realworld-round15-verify.json`。
+
+真实 MiniMax-M3 run `r15-2026-08-17`。CLI `6b966d4` = r14-eval-local `278164e`（r13 栈 #72+#73+#74+#75+#82+#83 @ `3053586` + #85 `550782c`，两处 keep-both）+ #87 `e1073f6`（本地 `r15-eval-local`；`qoder_strict_verifier.py` keep-both；**未推送、未进 main**）。未叠到 #86。R14 正文在 #86。
+
+| 项 | r14 | **r15** |
+|---|---|---|
+| CLI | `278164e` / r13 栈 + #85（未进 main） | **`6b966d4`** / r14 栈 + #87（未进 main） |
+| generate | EXIT=0；81/81；cache 0/81 | **EXIT=0；81/81；cache 0/81** |
+| LLM PASS / DEGRADED | 68 / 13 | **70 / 11** |
+| llm_call_count / tokens | 81 / 312531 | **81 / 302995** |
+| fallback | 13（全部 insufficient prose） | **11**（全部 insufficient prose） |
+| 529 / circuit-break | 0 / false | **0 / false** |
+| MiniMax 1004 | 0 | **0** |
+| coverage | 64.44%（928/1440）；门仍是 95% | **67.02%**（951/1419）仍 << 95% |
+| HARD / SOFT | 5 / 0 | **4 / 0**（未放宽） |
+| owner missing | 0 | **0** |
+| conflict（GitHub badges） | PASS | **PASS** |
+| API aggregation | PASS | **PASS** |
+| #87 leftover code | `CRITICAL_FALSE_FACT`（`DELETE /api/articles`） | **HIT**（PASS；claim_count 0） |
+
+不要声称 leftover HARD 已清。HARD 计数 5→4。不要松 HARD/SOFT。不要把这些产品 PR 合进 main。
 

--- a/docs/eval/2026-08-17-fastapi-realworld-round15-verify.json
+++ b/docs/eval/2026-08-17-fastapi-realworld-round15-verify.json
@@ -39,11 +39,13 @@
   "host": "api.minimaxi.com",
   "owner_check": "PASS",
   "owner_missing": 0,
+  "overview_conduit": true,
+  "overview_conduit_both_pages": true,
   "claim_coverage_percent": "67.02%",
   "claim_coverage": "951/1419",
   "claim_coverage_gate_percent": "95%",
   "relevance_mismatch": {"message": 25, "details": 20},
-  "api_aggregation": {"result": "PASS"},
+  "api_aggregation": {"result": "PASS", "score": "6/6"},
   "conflict": {
     "code": "QODER_UNRESOLVED_FACT_CONFLICT",
     "result": "PASS"
@@ -57,5 +59,5 @@
   "verify_exit": 1,
   "generate_wall": "11m10s",
   "verify_wall": "3s",
-  "note": "Real MiniMax-M3 run r15-2026-08-17. CLI 6b966d4 = r14-eval-local 278164e (r13 stack #72 #73 #74 #75 #82 #83 @ 3053586 + #85 550782c, two keep-both) + #87 e1073f6 (r15-eval-local; keep-both on qoder_strict_verifier.py; not pushed). HARD 4 / SOFT 0 (dropped vs R14 HARD 5). HIT vs R14 leftover: CRITICAL_FALSE_FACT PASS (#87). MISS: degraded (11 fallback), coverage 67.02% still << 95%, relevance, dirty worktree. Do not claim leftover HARD cleared. HARD count dropped 5→4. Gates not relaxed. Stack not pushed/merged."
+  "note": "Real MiniMax-M3 run r15-2026-08-17. CLI 6b966d4 = r14-eval-local 278164e (r13 stack #72 #73 #74 #75 #82 #83 @ 3053586 + #85 550782c, two keep-both) + #87 e1073f6 (r15-eval-local; keep-both on qoder_strict_verifier.py; not pushed). HARD 4 / SOFT 0 (dropped vs R14 HARD 5). HIT vs R14 leftover: CRITICAL_FALSE_FACT PASS (#87). API aggregation PASS 6/6 (same leftover-clear as R14). Overview Conduit HIT both pages (same as R14). MISS: degraded (11 fallback), coverage 67.02% still << 95%, relevance, dirty worktree. Do not claim leftover HARD cleared. HARD count dropped 5→4. Gates not relaxed. Stack not pushed/merged."
 }

--- a/docs/eval/2026-08-17-fastapi-realworld-round15-verify.json
+++ b/docs/eval/2026-08-17-fastapi-realworld-round15-verify.json
@@ -1,0 +1,61 @@
+{
+  "run_id": "r15-2026-08-17",
+  "cli": "6b966d4",
+  "cli_full": "6b966d447b0a7b1fde569ff3a96d630dc08a0bb2",
+  "cli_branch": "r15-eval-local",
+  "base_main": "1fe6840",
+  "prs": ["#72", "#73", "#74", "#75", "#82", "#83", "#85", "#87"],
+  "stacked_eval": "r14-eval-local 278164e (r13 stack #72 #73 #74 #75 #82 #83 @ 3053586 + #85 550782c, two keep-both) + #87 e1073f6 (cursor/fix-trailing-path-param-false-fact-194d) onto main 1fe6840; keep-both on qoder_strict_verifier.py preserved r14 helpers and #87 api_claim_in_inventory; not pushed",
+  "pr87_hit": "HIT",
+  "grade": "FAIL",
+  "hard_fail": 4,
+  "soft_fail": 0,
+  "hard_codes": [
+    "QODER_PAGE_QUALITY_STATE_DEGRADED",
+    "QODER_CITATION_FACT_COVERAGE_LOW",
+    "QODER_CITATION_RELEVANCE_MISMATCH",
+    "QODER_DIRTY_WORKTREE"
+  ],
+  "pages": {
+    "planned": 81,
+    "written": 81,
+    "pass": 70,
+    "degraded": 11,
+    "fallback": 11,
+    "llm_call_count": 81
+  },
+  "fallback_breakdown": {
+    "insufficient_prose": 11
+  },
+  "http_529": 0,
+  "minimax_1004": 0,
+  "circuit_break_tripped": false,
+  "provider_failure_count": 0,
+  "empty_content": 0,
+  "cache_hits": 0,
+  "cache_misses": 81,
+  "actual_tokens": 302995,
+  "timeout_s": 180,
+  "host": "api.minimaxi.com",
+  "owner_check": "PASS",
+  "owner_missing": 0,
+  "claim_coverage_percent": "67.02%",
+  "claim_coverage": "951/1419",
+  "claim_coverage_gate_percent": "95%",
+  "relevance_mismatch": {"message": 25, "details": 20},
+  "api_aggregation": {"result": "PASS"},
+  "conflict": {
+    "code": "QODER_UNRESOLVED_FACT_CONFLICT",
+    "result": "PASS"
+  },
+  "critical_false_fact": {
+    "result": "PASS",
+    "r14_shape": "DELETE /api/articles",
+    "claim_count": 0
+  },
+  "generate_exit": 0,
+  "verify_exit": 1,
+  "generate_wall": "11m10s",
+  "verify_wall": "3s",
+  "note": "Real MiniMax-M3 run r15-2026-08-17. CLI 6b966d4 = r14-eval-local 278164e (r13 stack #72 #73 #74 #75 #82 #83 @ 3053586 + #85 550782c, two keep-both) + #87 e1073f6 (r15-eval-local; keep-both on qoder_strict_verifier.py; not pushed). HARD 4 / SOFT 0 (dropped vs R14 HARD 5). HIT vs R14 leftover: CRITICAL_FALSE_FACT PASS (#87). MISS: degraded (11 fallback), coverage 67.02% still << 95%, relevance, dirty worktree. Do not claim leftover HARD cleared. HARD count dropped 5→4. Gates not relaxed. Stack not pushed/merged."
+}

--- a/docs/eval/2026-08-17-fastapi-realworld-round15.md
+++ b/docs/eval/2026-08-17-fastapi-realworld-round15.md
@@ -1,0 +1,76 @@
+# FastAPI RealWorld 对照 Wiki 第十五轮评测
+
+**对照仓：** nsidnev/fastapi-realworld-example-app `029eb7781c60d5f563ee8990a0cbfb79b244538c`
+**CLI：** `6b966d447b0a7b1fde569ff3a96d630dc08a0bb2`（本地分支 `r15-eval-local`；r14-eval-local `278164e` = r13 栈 #72–#75+#82+#83 @ `3053586` + #85 `550782c`，两处 keep-both，再 merge #87 `e1073f6`；`qoder_strict_verifier.py` keep-both 保留 r14 helpers 与 #87 `api_claim_in_inventory`；仅用于叠评测；**未推送**）
+**时间：** 2026-08-17 CST（generate 16:39:32–16:50:42 CST，wall **11m10s**；verify 16:51:23–16:51:26 CST，wall 3s）
+**run：** r15-2026-08-17
+**模型：** MiniMax-M3，host `api.minimaxi.com`，timeout 180，cache 0/81
+**verify JSON：** `docs/eval/2026-08-17-fastapi-realworld-round15-verify.json`
+
+本轮是真实 MiniMax generate，不是 MockLLM。
+
+第十四轮评测见 `docs/eval/2026-08-17-fastapi-realworld-round14.md`（#86，docs-only）。  
+对照 wrap 见 `docs/eval/2026-08-13-fastapi-realworld-wrap.md`。
+
+本 PR 只含评测文档。未改产品代码。未编辑 #71–#87。未把 #72–#75+#82+#83+#85+#87 推进 main。未叠到 #86。门槛未放宽。不要声称 leftover HARD 已清。HARD 计数 5→4。
+
+## Hits / Misses（相对 R14 leftover HARD）
+
+| leftover code | R14 | **R15** | |
+|---|---|---|---|
+| `QODER_PAGE_QUALITY_STATE_DEGRADED` | FAIL（13 fallback） | FAIL（11 fallback） | **MISS** |
+| `QODER_CRITICAL_FALSE_FACT` | FAIL（`DELETE /api/articles`，页 `API参考/核心服务API/API API.md`） | **PASS**（"Structured inventory claims are consistent"；inventory_types sources, apis, services, models, runtimes；claim_count 0） | **HIT（#87）** |
+| `QODER_CITATION_FACT_COVERAGE_LOW` | FAIL **64.44%**（928/1440）；门仍是 95% | FAIL **67.02%**（951/1419）；门仍是 95% | **MISS**（略升，仍 << 95%） |
+| `QODER_CITATION_RELEVANCE_MISMATCH` | FAIL（message 27 / details 20） | FAIL（message 25 / details 20） | **MISS** |
+| `QODER_DIRTY_WORKTREE` | FAIL（untracked `.repo-agent-eval/`） | FAIL（untracked `.repo-agent-eval/`） | **MISS** |
+
+#87 目标是 trailing path param false-fact（R14 形态 `DELETE /api/articles`）。本轮 `QODER_CRITICAL_FALSE_FACT` **HIT / PASS**。不要声称 leftover HARD 已清。HARD 5→4，计数下降但未清场。
+
+## Generate
+
+GENERATE_EXIT=0。Cold cache：cache_hits=0，cache_misses=81。isolated=true。
+
+| 项 | R14 | **R15** |
+|---|---|---|
+| planned / written | 81 / 81 | **81 / 81** |
+| LLM PASS / DEGRADED | 68 / 13 | **70 / 11** |
+| llm_call_count / tokens | 81 / 312531 | **81 / 302995** |
+| fallback | 13（全部 insufficient prose） | **11**（全部 insufficient prose） |
+| 529 / circuit-break | 0 / false | **0 / false** |
+| MiniMax 1004 | 0 | **0** |
+| provider_failure_count | 0 | **0** |
+| empty-content | 0 | **0** |
+| wall | 13m13s generate + 4s verify | **11m10s** generate + 3s verify |
+
+DEGRADED 11 页（全部 Insufficient prose content）：event-architecture、database-architecture、authentication-authorization-api、api-development、core-data-models、services、kubernetes-deployment、deployment-issues、vulnerability-management、testing-guide、performance-optimization。R14 为 13；本轮多过的两页属于更早 fallback 集合，不点名。
+
+## Compare
+
+| | R14 | **R15** |
+|---|---|---|
+| CLI | `278164e` / r13 栈 + #85 `550782c`（本地 `r14-eval-local`；未推送；未进 main） | **`6b966d4`** / r14 栈 + #87 `e1073f6`（本地 `r15-eval-local`；未推送；未进 main） |
+| coverage | 64.44%（928/1440）；门仍是 95% | **67.02%**（951/1419）仍 << 95% |
+| HARD / SOFT | 5 / 0 | **4 / 0**（未放宽） |
+| owner missing | 0 | **0** |
+| API aggregation | PASS | **PASS** |
+| conflict | PASS | **PASS** |
+| false-fact | `DELETE /api/articles`（1 claim） | **PASS**（#87 HIT；claim_count 0） |
+
+## Verify
+
+VERIFY_EXIT=1 / FAIL。HARD 4 / SOFT 0。Gates **not** relaxed。95% coverage 门未改。Checks：total 25，pass 20，warn 1，fail 4（R14 为 pass 19 / warn 1 / fail 5）。
+
+WARN（不是 extra HARD）：`QODER_MANIFEST_NOT_READY`（target_dirty=true）— 与 R14 同一形态。
+
+Leftover HARD：
+
+1. `QODER_PAGE_QUALITY_STATE_DEGRADED`（11 fallback，全部 insufficient prose）
+2. `QODER_CITATION_FACT_COVERAGE_LOW` 67.02%（951/1419）vs R14 64.44%；门仍是 95%
+3. `QODER_CITATION_RELEVANCE_MISMATCH`（message 25 / details 20；details 全部 "citation path indicates different service"：Db.md ×5 → `app/models/domain/users.py`（expected database）；API.md ×1 → `tests/test_schemas/test_rw_model.py`（expected api）；API参考.md ×3 `app/db/queries/tables.py` + ×1 `app/models/domain/users.py`（expected api）；API API.md ×2 `app/db/queries/tables.py` + ×2 `tests/test_schemas/test_rw_model.py`（expected api）；核心服务API.md ×3 `app/db/queries/tables.py` + ×2 `tests/test_schemas/test_rw_model.py`（expected api）；Python服务API.md ×1 `app/db/queries/tables.py`（expected api））
+4. `QODER_DIRTY_WORKTREE`（untracked `.repo-agent-eval/`）
+
+SOFT none。
+
+不要把 HARD 5→4 解读成 leftover HARD 清场，也不要解读成门槛放松。#87 只 HIT 了 `QODER_CRITICAL_FALSE_FACT`。
+
+不要在本评测 PR 里改产品代码。不要把 #72–#75+#82+#83+#85+#87 合进 main。

--- a/docs/eval/2026-08-17-fastapi-realworld-round15.md
+++ b/docs/eval/2026-08-17-fastapi-realworld-round15.md
@@ -23,6 +23,8 @@
 | `QODER_CITATION_FACT_COVERAGE_LOW` | FAIL **64.44%**（928/1440）；门仍是 95% | FAIL **67.02%**（951/1419）；门仍是 95% | **MISS**（略升，仍 << 95%） |
 | `QODER_CITATION_RELEVANCE_MISMATCH` | FAIL（message 27 / details 20） | FAIL（message 25 / details 20） | **MISS** |
 | `QODER_DIRTY_WORKTREE` | FAIL（untracked `.repo-agent-eval/`） | FAIL（untracked `.repo-agent-eval/`） | **MISS** |
+| `QODER_API_AGGREGATION_LOW` | PASS 6/6 | **PASS 6/6** | 与 R14 同一 leftover-clear |
+| Overview Conduit | HIT（两张 overview 页） | **HIT**（两张 overview 页） | 与 R14 相同 |
 
 #87 目标是 trailing path param false-fact（R14 形态 `DELETE /api/articles`）。本轮 `QODER_CRITICAL_FALSE_FACT` **HIT / PASS**。不要声称 leftover HARD 已清。HARD 5→4，计数下降但未清场。
 
@@ -40,6 +42,7 @@ GENERATE_EXIT=0。Cold cache：cache_hits=0，cache_misses=81。isolated=true。
 | MiniMax 1004 | 0 | **0** |
 | provider_failure_count | 0 | **0** |
 | empty-content | 0 | **0** |
+| Overview Conduit | HIT（两张 overview 页） | **HIT**（两张 overview 页） |
 | wall | 13m13s generate + 4s verify | **11m10s** generate + 3s verify |
 
 DEGRADED 11 页（全部 Insufficient prose content）：event-architecture、database-architecture、authentication-authorization-api、api-development、core-data-models、services、kubernetes-deployment、deployment-issues、vulnerability-management、testing-guide、performance-optimization。R14 为 13；本轮多过的两页属于更早 fallback 集合，不点名。
@@ -52,8 +55,9 @@ DEGRADED 11 页（全部 Insufficient prose content）：event-architecture、da
 | coverage | 64.44%（928/1440）；门仍是 95% | **67.02%**（951/1419）仍 << 95% |
 | HARD / SOFT | 5 / 0 | **4 / 0**（未放宽） |
 | owner missing | 0 | **0** |
-| API aggregation | PASS | **PASS** |
+| API aggregation | PASS 6/6 | **PASS 6/6** |
 | conflict | PASS | **PASS** |
+| Overview Conduit | HIT（两张 overview 页） | **HIT**（两张 overview 页） |
 | false-fact | `DELETE /api/articles`（1 claim） | **PASS**（#87 HIT；claim_count 0） |
 
 ## Verify

--- a/docs/plans/current-roadmap.md
+++ b/docs/plans/current-roadmap.md
@@ -22,7 +22,7 @@
 
 - qoder-like 隔离输出与 HARD/SOFT 门禁（不放宽）
 - FastAPI 对照闭环里已修：路由前缀 / `settings.api_prefix`、产品身份（README/pyproject → overview）、`file:` 引用、mounted `/api` owner 绑定（#43–#59）
-- Codex plugin #50；R8 评测见 `docs/eval/2026-08-14-fastapi-realworld-round8.md`；R9 评测见 `docs/eval/2026-08-14-fastapi-realworld-round9.md`；R10 评测见 `docs/eval/2026-08-14-fastapi-realworld-round10.md`
+- Codex plugin #50；R8 评测见 `docs/eval/2026-08-14-fastapi-realworld-round8.md`；R9 评测见 `docs/eval/2026-08-14-fastapi-realworld-round9.md`；R10 评测见 `docs/eval/2026-08-14-fastapi-realworld-round10.md`；R15 评测见 `docs/eval/2026-08-17-fastapi-realworld-round15.md`
 
 ## 本周期（先把单库 Wiki 做准）
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
R14 leftover HARD after real MiniMax-M3 `r14-2026-08-17` / #86. This PR records **real MiniMax-M3 R15** after locally stacking #87 `e1073f6` onto the r14 CLI (`r14-eval-local` `278164e` = `#72–#75+#82+#83` @ `3053586` + #85 `550782c`; CLI `6b966d447b0a7b1fde569ff3a96d630dc08a0bb2`, branch `r15-eval-local`, keep-both on `qoder_strict_verifier.py` preserved r14 helpers and #87 `api_claim_in_inventory`, not pushed). Contrast nsidnev/fastapi-realworld-example-app `029eb778`.

GENERATE_EXIT=0. VERIFY_EXIT=1. HARD **4** / SOFT **0** (dropped vs R14 HARD 5). Coverage **67.02%** (951/1419) vs R14 64.44%; gate still 95%. 81/81 pages, 70 PASS / 11 DEGRADED. Cache 0/81. llm_call_count=81, actual_tokens=302995. 11 fallback (all insufficient prose). provider_failure_count=0, circuit-break false, empty-content 0, 529 0, MiniMax 1004 0. Overview Conduit HIT on both overview pages. API aggregation PASS 6/6 (same leftover-clear as R14). Generate wall 11m10s; verify 3s.

| leftover code | vs R14 | |
|---|---|---|
| `QODER_PAGE_QUALITY_STATE_DEGRADED` | FAIL (11 fallback) | **MISS** |
| `QODER_CRITICAL_FALSE_FACT` | PASS | **HIT (#87)** |
| `QODER_CITATION_FACT_COVERAGE_LOW` | FAIL 67.02% (R14 64.44%) | **MISS** |
| `QODER_CITATION_RELEVANCE_MISMATCH` | FAIL (message 25 / details 20) | **MISS** |
| `QODER_DIRTY_WORKTREE` | FAIL (untracked `.repo-agent-eval/`) | **MISS** |

Do not claim leftover HARD is cleared. HARD count dropped 5→4.

## Type of Change
- [x] Documentation update (typos, docs, etc.)

Docs only. No product-code change. Gates not relaxed. Starts from main. Does not stack onto #86. Does not edit #71–#87. Do not merge product PRs via this PR. Do not merge until reviewed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1edc4d2-3bba-4c64-817a-224625e53e5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1edc4d2-3bba-4c64-817a-224625e53e5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

