### PR TITLE
docs: FastAPI RealWorld round-16 eval after #89

### DIFF
--- a/docs/eval/2026-08-13-fastapi-realworld-wrap.md
+++ b/docs/eval/2026-08-13-fastapi-realworld-wrap.md
@@ -1,6 +1,6 @@
 # FastAPI RealWorld wiki 质量对照 wrap
 
-**日期：** 2026-08-13–2026-08-14 CST  
+**日期：** 2026-08-13–2026-08-18 CST  
 **对照：** nsidnev/fastapi-realworld-example-app `029eb778` × MiniMax-M3  
 **CLI：** r1 `9cadf85`（#40）→ r2 `c2407979`（#42 空 content 重试 + #43 FastAPI 扫描）→ r3 `a3d58b4`（#45 导入 router 前缀拼接）→ r4 `9328896`（#50；含 #48 `api_prefix` + #49 circuit-break）→ r5 `8912c89`（#52 README/身份优先于 init stub 与 eval notes）→ r6 `b0a06f4`（#54 README.rst 解析 + pyproject fallback）→ r7 `2e3a3f0`（#56 identity.description 流入 overview）→ r8 `05bb3b8`（#58 去掉 citation `file:` 前缀）
 
@@ -13,7 +13,8 @@
 第七轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round7.md`。  
 第八轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round8.md`。  
 第九轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round9.md`。  
-第十轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round10.md`。
+第十轮评测见 `docs/eval/2026-08-14-fastapi-realworld-round10.md`。  
+第十六轮评测见 `docs/eval/2026-08-18-fastapi-realworld-round16.md`。
 
 ## r1 vs r2
 
@@ -229,4 +230,29 @@ verify JSON：`docs/eval/2026-08-14-fastapi-realworld-round8-verify.json`。
 - taxonomy 幻觉页；泄漏 `<think>` 89 页。
 - coverage 42.28% 仍 << 95%；eval-layout HARD；API mermaid 缺 9 / ER 缺 5。
 - r8 verify：**12 HARD / 0 SOFT**（未放宽）。不要松阈值。
+
+## r15 vs r16
+
+评测正文：`docs/eval/2026-08-18-fastapi-realworld-round16.md`。  
+verify JSON：`docs/eval/2026-08-18-fastapi-realworld-round16-verify.json`。
+
+真实 MiniMax-M3 run `r16-2026-08-18`。CLI `c8a30a6` = r15-eval-local `6b966d4`（r14 `278164e` + #87 `e1073f6`）+ #89 `025d7d2`（本地 `r16-eval-local`；auto-merge，无需 keep-both；**未推送、未进 main**）。未叠到 #88。R15 正文在 #88。
+
+| 项 | r15 | **r16** |
+|---|---|---|
+| CLI | `6b966d4` / r14 栈 + #87（未进 main） | **`c8a30a6`** / r15 栈 + #89（未进 main） |
+| generate | EXIT=0；81/81；cache 0/81 | **EXIT=0；81/81；cache 0/81** |
+| LLM PASS / DEGRADED | 70 / 11 | **77 / 4** |
+| llm_call_count / tokens | 81 / 302995 | **81 / 323357** |
+| fallback | 11（全部 insufficient prose） | **4**（insufficient prose 3 + http 529 1） |
+| 529 / circuit-break | 0 / false | **1 / false** |
+| MiniMax 1004 | 0 | **0** |
+| coverage | 67.02%（951/1419）；门仍是 95% | **68.76%**（940/1367）仍 << 95% |
+| HARD / SOFT | 4 / 0 | **3 / 0**（未放宽） |
+| owner missing | 0 | **0** |
+| conflict | PASS | **PASS** |
+| API aggregation | PASS 6/6 | **PASS 6/6** |
+| #89 leftover code | `CITATION_RELEVANCE_MISMATCH`（message 25 / details 20） | **HIT**（PASS；mismatches n=0） |
+
+不要声称 leftover HARD 已清。HARD 计数 4→3。不要松 HARD/SOFT。不要把这些产品 PR 合进 main。
 

--- a/docs/eval/2026-08-18-fastapi-realworld-round16-verify.json
+++ b/docs/eval/2026-08-18-fastapi-realworld-round16-verify.json
@@ -1,0 +1,60 @@
+{
+  "run_id": "r16-2026-08-18",
+  "cli": "c8a30a6",
+  "cli_full": "c8a30a690a95ab13692f186c6ee59190dec4ead4",
+  "cli_branch": "r16-eval-local",
+  "base_main": "1fe6840",
+  "prs": ["#72", "#73", "#74", "#75", "#82", "#83", "#85", "#87", "#89"],
+  "stacked_eval": "r15-eval-local 6b966d4 (r14 278164e + #87 e1073f6) + merge of #89 025d7d2272836cea6c6416e4bd04131a9ec5bd8e (cursor/fix-fastapi-sibling-layer-relevance-2e1d) onto main 1fe6840; auto-merge, no keep-both; not pushed, not merged to origin/main",
+  "pr89_hit": "HIT",
+  "grade": "FAIL",
+  "hard_fail": 3,
+  "soft_fail": 0,
+  "hard_codes": [
+    "QODER_PAGE_QUALITY_STATE_DEGRADED",
+    "QODER_CITATION_FACT_COVERAGE_LOW",
+    "QODER_DIRTY_WORKTREE"
+  ],
+  "pages": {
+    "planned": 81,
+    "written": 81,
+    "pass": 77,
+    "degraded": 4,
+    "fallback": 4,
+    "llm_call_count": 81
+  },
+  "fallback_breakdown": {
+    "insufficient_prose": 3,
+    "http_529": 1
+  },
+  "http_529": 1,
+  "minimax_1004": 0,
+  "circuit_break_tripped": false,
+  "provider_failure_count": 0,
+  "empty_content": 0,
+  "cache_hits": 0,
+  "cache_misses": 81,
+  "actual_tokens": 323357,
+  "timeout_s": 180,
+  "host": "api.minimaxi.com",
+  "owner_check": "PASS",
+  "owner_missing": 0,
+  "claim_coverage_percent": "68.76%",
+  "claim_coverage": "940/1367",
+  "claim_coverage_gate_percent": "95%",
+  "relevance": "PASS",
+  "relevance_mismatch": {"result": "PASS", "n": 0},
+  "api_aggregation": {"result": "PASS", "score": "6/6"},
+  "conflict": {
+    "code": "QODER_UNRESOLVED_FACT_CONFLICT",
+    "result": "PASS"
+  },
+  "critical_false_fact": {
+    "result": "PASS"
+  },
+  "generate_exit": 0,
+  "verify_exit": 1,
+  "generate_wall": "15m56s",
+  "verify_wall": "3s",
+  "note": "Real MiniMax-M3 run r16-2026-08-18. CLI c8a30a6 = r15-eval-local 6b966d4 (r14 278164e + #87 e1073f6) + #89 025d7d2 (r16-eval-local; auto-merge, no keep-both; not pushed). HARD 3 / SOFT 0 (dropped vs R15 HARD 4). HIT vs R15 leftover: CITATION_RELEVANCE_MISMATCH PASS (#89). API aggregation PASS 6/6 (same leftover-clear as R15). MISS: degraded (4 fallback: 3 insufficient prose + 1x529), coverage 68.76% still << 95%, dirty worktree. 1x529 on security-best-practices is a provider blip, not a relevance wiring miss. Not an 81-fallback auth-1004 run. Do not claim leftover HARD cleared. HARD count dropped 4→3. Gates not relaxed. Stack not pushed/merged."
+}

--- a/docs/eval/2026-08-18-fastapi-realworld-round16.md
+++ b/docs/eval/2026-08-18-fastapi-realworld-round16.md
@@ -1,0 +1,83 @@
+# FastAPI RealWorld 对照 Wiki 第十六轮评测
+
+**对照仓：** nsidnev/fastapi-realworld-example-app `029eb7781c60d5f563ee8990a0cbfb79b244538c`
+**CLI：** `c8a30a690a95ab13692f186c6ee59190dec4ead4`（本地分支 `r16-eval-local`；r15-eval-local `6b966d4` = r14 `278164e` + #87 `e1073f6`，再 merge #89 `025d7d2272836cea6c6416e4bd04131a9ec5bd8e`（`cursor/fix-fastapi-sibling-layer-relevance-2e1d`）；auto-merge，无需 keep-both；仅用于叠评测；**未推送、未进 origin/main**）
+**时间：** 2026-08-18 CST（generate 08:58:39–09:14:35 CST，wall **15m56s** / compose 955.3s；verify 09:15:16–09:15:19 CST，wall 3s）
+**run：** r16-2026-08-18
+**模型：** MiniMax-M3，host `api.minimaxi.com`，timeout 180，cache 0/81
+**verify JSON：** `docs/eval/2026-08-18-fastapi-realworld-round16-verify.json`
+
+本轮是真实 MiniMax generate，不是 MockLLM。
+
+第十五轮评测见 `docs/eval/2026-08-17-fastapi-realworld-round15.md`（#88，docs-only）。  
+对照 wrap 见 `docs/eval/2026-08-13-fastapi-realworld-wrap.md`。
+
+本 PR 只含评测文档。未改产品代码。未编辑 #71–#89。未把 #72–#75+#82+#83+#85+#87+#89 推进 main。未叠到 #88。门槛未放宽。不要声称 leftover HARD 已清。HARD 计数 4→3。
+
+## Hits / Misses（相对 R15 leftover HARD）
+
+| leftover code | R15 | **R16** | |
+|---|---|---|---|
+| `QODER_PAGE_QUALITY_STATE_DEGRADED` | FAIL（11 fallback） | FAIL（4 fallback） | **MISS**（11→4，仍是 HARD） |
+| `QODER_CITATION_FACT_COVERAGE_LOW` | FAIL **67.02%**（951/1419）；门仍是 95% | FAIL **68.76%**（940/1367）；门仍是 95% | **MISS**（略升，仍 << 95%） |
+| `QODER_CITATION_RELEVANCE_MISMATCH` | FAIL（message 25 / details 20） | **PASS**（"All citations appear relevant to their pages"；mismatches n=0） | **HIT（#89）** |
+| `QODER_DIRTY_WORKTREE` | FAIL（untracked `.repo-agent-eval/`） | FAIL（untracked `.repo-agent-eval/`） | **MISS** |
+| `QODER_API_AGGREGATION_LOW` | PASS 6/6 | **PASS 6/6** | 与 R15 同一 leftover-clear |
+
+#89 目标是 sibling-layer citation relevance（R15 形态 `QODER_CITATION_RELEVANCE_MISMATCH`）。本轮该门 **HIT / PASS**。1×529 是单页 provider blip（`security-best-practices`），不是 relevance 接线漏。不要声称 leftover HARD 已清。HARD 4→3，计数下降但未清场。
+
+## Generate
+
+GENERATE_EXIT=0。Cold cache：cache_hits=0，cache_misses=81。isolated=true。不是 81-fallback auth-1004 run。
+
+| 项 | R15 | **R16** |
+|---|---|---|
+| planned / written | 81 / 81 | **81 / 81** |
+| LLM PASS / DEGRADED | 70 / 11 | **77 / 4** |
+| llm_call_count / tokens | 81 / 302995 | **81 / 323357** |
+| fallback | 11（全部 insufficient prose） | **4**（insufficient prose 3 + http 529 1） |
+| 529 / circuit-break | 0 / false | **1 / false** |
+| MiniMax 1004 | 0 | **0** |
+| provider_failure_count | 0 | **0** |
+| empty-content | 0 | **0** |
+| wall | 11m10s generate + 3s verify | **15m56s** generate + 3s verify |
+
+DEGRADED 4 页：
+
+- project-overview / `项目概述/项目概述.md` — Insufficient prose content
+- installation / `项目概述/安装与配置.md` — Insufficient prose content
+- security-overview / `安全合规.md` — Insufficient prose content
+- security-best-practices / `安全合规/安全最佳实践.md` — Composition error: Server error: 529
+
+## Compare
+
+| | R15 | **R16** |
+|---|---|---|
+| CLI | `6b966d4` / r14 栈 + #87 `e1073f6`（本地 `r15-eval-local`；未推送；未进 main） | **`c8a30a6`** / r15 栈 + #89 `025d7d2`（本地 `r16-eval-local`；未推送；未进 main） |
+| coverage | 67.02%（951/1419）；门仍是 95% | **68.76%**（940/1367）仍 << 95% |
+| HARD / SOFT | 4 / 0 | **3 / 0**（未放宽） |
+| owner missing | 0 | **0** |
+| API aggregation | PASS 6/6 | **PASS 6/6** |
+| conflict | PASS | **PASS** |
+| page dumps | PASS | **PASS** |
+| prose density | PASS | **PASS** |
+| false-fact | PASS（#87 HIT） | **PASS** |
+| relevance | FAIL（message 25 / details 20） | **PASS**（#89 HIT；n=0） |
+
+## Verify
+
+VERIFY_EXIT=1 / FAIL。HARD 3 / SOFT 0。Gates **not** relaxed。95% coverage 门未改。Checks：total 25，pass 21，warn 1，fail 3（R15 为 pass 20 / warn 1 / fail 4）。
+
+WARN（不是 extra HARD）：`QODER_MANIFEST_NOT_READY`（target_dirty=true）— 与 R15 同一形态。
+
+Leftover HARD：
+
+1. `QODER_PAGE_QUALITY_STATE_DEGRADED`（4 fallback：insufficient prose 3 + http 529 1）
+2. `QODER_CITATION_FACT_COVERAGE_LOW` 68.76%（940/1367）vs R15 67.02%；门仍是 95%
+3. `QODER_DIRTY_WORKTREE`（untracked `.repo-agent-eval/`）
+
+SOFT none。
+
+不要把 HARD 4→3 解读成 leftover HARD 清场，也不要解读成门槛放松。#89 只 HIT 了 `QODER_CITATION_RELEVANCE_MISMATCH`。
+
+不要在本评测 PR 里改产品代码。不要把 #72–#75+#82+#83+#85+#87+#89 合进 main。

--- a/docs/plans/current-roadmap.md
+++ b/docs/plans/current-roadmap.md
@@ -22,7 +22,7 @@
 
 - qoder-like 隔离输出与 HARD/SOFT 门禁（不放宽）
 - FastAPI 对照闭环里已修：路由前缀 / `settings.api_prefix`、产品身份（README/pyproject → overview）、`file:` 引用、mounted `/api` owner 绑定（#43–#59）
-- Codex plugin #50；R8 评测见 `docs/eval/2026-08-14-fastapi-realworld-round8.md`；R9 评测见 `docs/eval/2026-08-14-fastapi-realworld-round9.md`；R10 评测见 `docs/eval/2026-08-14-fastapi-realworld-round10.md`
+- Codex plugin #50；R8 评测见 `docs/eval/2026-08-14-fastapi-realworld-round8.md`；R9 评测见 `docs/eval/2026-08-14-fastapi-realworld-round9.md`；R10 评测见 `docs/eval/2026-08-14-fastapi-realworld-round10.md`；R16 评测见 `docs/eval/2026-08-18-fastapi-realworld-round16.md`
 
 ## 本周期（先把单库 Wiki 做准）
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
R15 leftover HARD after real MiniMax-M3 `r15-2026-08-17` / #88. This PR records **real MiniMax-M3 R16** after locally stacking #89 `025d7d2` onto the r15 CLI (`r15-eval-local` `6b966d4` = r14 `278164e` + #87 `e1073f6`; CLI `c8a30a690a95ab13692f186c6ee59190dec4ead4`, branch `r16-eval-local`, auto-merge with no keep-both, not pushed). Contrast nsidnev/fastapi-realworld-example-app `029eb778`.

GENERATE_EXIT=0. VERIFY_EXIT=1. HARD **3** / SOFT **0** (dropped vs R15 HARD 4). Coverage **68.76%** (940/1367) vs R15 67.02%; gate still 95%. 81/81 pages, 77 PASS / 4 DEGRADED. Cache 0/81. llm_call_count=81, actual_tokens=323357. 4 fallback (3 insufficient prose + 1×529 on `security-best-practices`). provider_failure_count=0, circuit-break false, empty-content 0, MiniMax 1004 0. API aggregation PASS 6/6 (same leftover-clear as R15). Generate wall 15m56s; verify 3s. Not an 81-fallback auth-1004 run.

| leftover code | vs R15 | |
|---|---|---|
| `QODER_PAGE_QUALITY_STATE_DEGRADED` | FAIL (4 fallback; was 11) | **MISS** |
| `QODER_CITATION_FACT_COVERAGE_LOW` | FAIL 68.76% (R15 67.02%) | **MISS** |
| `QODER_CITATION_RELEVANCE_MISMATCH` | PASS (mismatches n=0) | **HIT (#89)** |
| `QODER_DIRTY_WORKTREE` | FAIL (untracked `.repo-agent-eval/`) | **MISS** |

Do not claim leftover HARD is cleared. HARD count dropped 4→3. 1×529 is a provider blip on one page, not a wiring miss for relevance.

## Type of Change
- [x] Documentation update (typos, docs, etc.)

Docs only. No product-code change. Gates not relaxed. Starts from main. Does not stack onto #88. Does not edit #71–#89. Do not merge product PRs via this PR. Do not merge until reviewed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35e9f44b-0726-499f-82b7-9c98f892eda9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35e9f44b-0726-499f-82b7-9c98f892eda9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

