### PR TITLE
fix: write fallback wiki pages as onboarding docs, not generator meta

### DIFF
--- a/repo_wiki/orchestration/service.py
+++ b/repo_wiki/orchestration/service.py
@@ -1479,143 +1479,183 @@ class RepoWikiService:
         )
         cache.record_regenerated_page()
 
+    def _fallback_cite(self, item: dict[str, Any]) -> str:
+        path = str(item.get("path") or "").strip()
+        if not path:
+            return ""
+        start = int(item.get("line_start") or 1)
+        end = int(item.get("line_end") or start)
+        if end != start:
+            return f"<cite>{path}:{start}-{end}</cite>"
+        return f"<cite>{path}:{start}</cite>"
+
+    def _fallback_is_onboarding_page(self, page: Any) -> bool:
+        from repo_wiki.planner.schema import WikiTaxonomyCategory
+
+        category = getattr(page, "category", None)
+        if category in {
+            WikiTaxonomyCategory.PROJECT_OVERVIEW,
+            WikiTaxonomyCategory.DEVELOPMENT_GUIDE,
+            WikiTaxonomyCategory.DEPLOYMENT_OPERATIONS,
+        }:
+            return True
+        blob = " ".join(
+            [
+                str(getattr(page, "title", "") or ""),
+                str(getattr(page, "page_id", "") or ""),
+                " ".join(str(tag) for tag in (getattr(page, "tags", None) or [])),
+            ]
+        ).lower()
+        return any(
+            token in blob
+            for token in ("install", "安装", "quickstart", "快速开始", "getting-started", "setup")
+        )
+
+    def _fallback_empty_notice(self, title: str) -> list[str]:
+        return [
+            f"本页目前无法根据仓库内容写成可用的「{title}」说明。",
+            "",
+            "当前没有匹配到与本主题相关的文档或源码片段，因此这里不能描述项目是什么、怎样安装，"
+            "或怎样做访问控制。本页也不会列出并不存在于仓库证据中的文件路径。",
+            "",
+            "接手仓库的人需要先在仓库根目录自行查看现有文档、启动配置和源码。"
+            "在找到可核对的文件之前，请不要把本页当成安装、运行或安全方面的事实来源。",
+            "",
+            "这里留空是为了避免用其他项目的安装步骤或合规套话充数，而不是因为主题不重要。",
+        ]
+
+    def _fallback_snippet_paragraphs(
+        self, evidence: dict[str, Any], *, limit: int = 4
+    ) -> list[str]:
+        lines: list[str] = []
+        for item in (evidence.get("snippets") or [])[:limit]:
+            path = str(item.get("path") or "").strip()
+            summary = str(item.get("summary") or "").strip()
+            if not path or not summary:
+                continue
+            cite = self._fallback_cite(item)
+            symbol = str(item.get("symbol") or "").strip()
+            if symbol:
+                intro = f"仓库文件 `{path}` 中与 `{symbol}` 相关的原文如下。"
+            else:
+                intro = f"仓库文件 `{path}` 中的相关说明如下。"
+            if cite:
+                intro = f"{intro} {cite}"
+            lines.extend([intro, "", summary, ""])
+        return lines
+
+    def _fallback_related_files_section(self, evidence: dict[str, Any]) -> list[str]:
+        files = evidence.get("files") or []
+        if not files:
+            return []
+        lines = [
+            "## 可核对的文件",
+            "",
+            "下面这些路径来自本页已经绑定到的仓库文件，打开即可看到完整上下文。",
+            "",
+        ]
+        for item in files[:6]:
+            cite = self._fallback_cite(item)
+            symbol = str(item.get("symbol") or "").strip()
+            if not cite:
+                continue
+            if symbol:
+                lines.append(f"- {cite}（`{symbol}`）")
+            else:
+                lines.append(f"- {cite}")
+        lines.extend(
+            [
+                "",
+                "这些引用只用于跳转到仓库内的真实位置，并不表示本页对未摘录的内容做了额外推断。",
+                "",
+            ]
+        )
+        return lines
+
+    def _fallback_onboarding_markdown(self, title: str, evidence: dict[str, Any]) -> list[str]:
+        snippets = self._fallback_snippet_paragraphs(evidence)
+        lines = [
+            "## 这是什么",
+            "",
+            f"「{title}」面向刚接手本仓库的读者，说明这个项目是做什么的，以及怎样在本地跑起来。",
+            "下面只复述仓库文档和源码里已经出现的内容，不补充仓库之外的通用安装或架构说法。",
+            "",
+        ]
+        if snippets:
+            lines.extend(
+                [
+                    "根据仓库文档，项目说明与启动方式如下。",
+                    "",
+                    *snippets,
+                    "## 如何运行",
+                    "",
+                    "启动、依赖和测试步骤以上面的文档摘录为准。"
+                    "请按原文中的命令、环境变量和依赖核对本地环境，本页不另写一套未出现在仓库文档里的安装步骤。",
+                    "",
+                    "如果摘录是英文，含义仍以原文为准；中文段落只帮助定位该看哪一段。",
+                    "",
+                ]
+            )
+        else:
+            lines.extend(self._fallback_empty_notice(title))
+            lines.append("")
+        lines.extend(self._fallback_related_files_section(evidence))
+        return lines
+
+    def _fallback_security_markdown(self, title: str, evidence: dict[str, Any]) -> list[str]:
+        snippets = self._fallback_snippet_paragraphs(evidence)
+        lines = [
+            "## 当前仓库里能看到的控制",
+            "",
+            f"「{title}」只描述源码或配置里实际出现的认证、授权或访问控制，"
+            "不套用通用合规清单，也不对未出现的审计、加密或认证框架下结论。",
+            "",
+        ]
+        if snippets:
+            lines.extend(
+                [
+                    "与本页相关的实现摘录如下。请按原文理解请求头、令牌或权限检查，不要把未出现的合规要求写进本页。",
+                    "",
+                    *snippets,
+                    "阅读时以引用文件中的实现为准。本页没有额外的安全承诺。",
+                    "",
+                ]
+            )
+        else:
+            lines.extend(self._fallback_empty_notice(title))
+            lines.append("")
+        lines.extend(self._fallback_related_files_section(evidence))
+        return lines
+
+    def _fallback_topic_markdown(self, title: str, evidence: dict[str, Any]) -> list[str]:
+        snippets = self._fallback_snippet_paragraphs(evidence)
+        lines = [
+            "## 说明",
+            "",
+            f"「{title}」根据仓库中的相关文件整理，供接手代码的人定位实现。",
+            "下面列出可核对位置，并摘录片段中的原话。本页不解释文档是如何生成的。",
+            "",
+        ]
+        if snippets:
+            lines.extend(snippets)
+        else:
+            lines.extend(self._fallback_empty_notice(title))
+            lines.append("")
+        lines.extend(self._fallback_related_files_section(evidence))
+        return lines
+
     def _fallback_markdown_for_failed_page(self, page: Any, binding: Any | None) -> str:
         from repo_wiki.planner.schema import WikiTaxonomyCategory
 
         evidence = self._summarize_evidence_for_fallback(binding)
-        modules = ", ".join(evidence["modules"][:5]) if evidence["modules"] else "仓库根模块"
-        symbols = "、".join(evidence["symbols"][:6]) if evidence["symbols"] else page.title
-        file_count = len(evidence["files"])
-
-        category_intro = {
-            WikiTaxonomyCategory.PROJECT_OVERVIEW: "本页从项目定位、关键能力和入口文件解释仓库整体形态。",
-            WikiTaxonomyCategory.ARCHITECTURE_DESIGN: "本页从模块边界、调用关系和数据流解释系统架构。",
-            WikiTaxonomyCategory.CORE_SERVICES: "本页聚焦服务职责、核心组件和上下游协作。",
-            WikiTaxonomyCategory.PYTHON_SERVICES: "本页聚焦 Python 服务的运行入口、依赖和处理流程。",
-            WikiTaxonomyCategory.FRONTEND_APPLICATIONS: "本页聚焦前端应用结构、页面职责和后端接口依赖。",
-            WikiTaxonomyCategory.DATA_MODELS: "本页聚焦实体族、服务模型和持久化结构。",
-            WikiTaxonomyCategory.API_REFERENCE: "本页聚焦 API 服务族、调用约定和错误处理边界。",
-            WikiTaxonomyCategory.DEPLOYMENT_OPERATIONS: "本页聚焦部署配置、运行环境和运维检查点。",
-            WikiTaxonomyCategory.DEVELOPMENT_GUIDE: "本页聚焦开发入口、命令约定和本地调试路径。",
-            WikiTaxonomyCategory.SECURITY_COMPLIANCE: "本页聚焦认证授权、审计记录和安全控制点。",
-            WikiTaxonomyCategory.TROUBLESHOOTING: "本页聚焦常见故障、定位线索和恢复策略。",
-        }.get(page.category, "本页基于仓库证据解释对应主题。")
-
-        lines = [
-            f"# {page.title}",
-            "",
-            "## 简介",
-            "",
-            f"{category_intro} 该页面对应 `{page.page_id}`，当前由 repo-agent 的证据驱动 fallback composer 生成。",
-            f"生成器从 {file_count} 个相关源文件中抽取候选证据，重点覆盖 `{modules}` 等范围。",
-            "与普通索引页不同，本页会把证据位置、组件职责、调用边界和维护风险组织成可阅读的专题说明。",
-            "",
-            "## 项目结构",
-            "",
-            f"围绕 **{page.title}**，当前仓库中最相关的代码集中在 `{modules}`。",
-            f"证据排名显示，`{symbols}` 是阅读该主题时优先关注的符号或配置点。",
-            "这些文件共同构成页面主题的事实来源：上层说明只描述能被源码片段或配置片段支撑的内容。",
-            "",
-            "## 核心组件",
-            "",
-        ]
-
-        if evidence["files"]:
-            for item in evidence["files"][:6]:
-                lines.append(
-                    f"- `{item['path']}`：关联符号 `{item['symbol']}`，覆盖第 {item['line_start']}-{item['line_end']} 行。"
-                )
+        title = str(getattr(page, "title", "") or "仓库说明")
+        if self._fallback_is_onboarding_page(page):
+            body = self._fallback_onboarding_markdown(title, evidence)
+        elif getattr(page, "category", None) == WikiTaxonomyCategory.SECURITY_COMPLIANCE:
+            body = self._fallback_security_markdown(title, evidence)
         else:
-            lines.append("- 当前页面没有匹配到高置信源码片段，后续需要补充扫描规则或页面规划规则。")
-
-        lines.extend(
-            [
-                "",
-                "## 详细组件分析",
-                "",
-                "从证据片段看，本主题的实现通常不是单点文件完成，而是由入口、配置、模型和服务逻辑共同支撑。",
-                "阅读时应先确认入口文件，再追踪模型和服务层的引用关系，最后查看部署或测试文件中的运行约束。",
-                "如果某个符号同时出现在多个服务目录中，应优先把它理解为跨服务契约，而不是孤立类或函数。",
-                "",
-            ]
-        )
-
-        for item in evidence["snippets"][:4]:
-            lines.extend(
-                [
-                    f"### {item['symbol']}",
-                    "",
-                    f"`{item['path']}` 的片段显示：{item['summary']}",
-                    "该证据用于限定本文的描述范围，避免生成与仓库无关的通用说明。",
-                    "",
-                ]
-            )
-
-        if page.category == WikiTaxonomyCategory.API_REFERENCE:
-            lines.extend(
-                [
-                    "## 依赖关系分析",
-                    "",
-                    "API 页面需要同时关注 controller/router、请求响应模型、认证拦截器和错误处理路径。",
-                    "服务族的 GET、POST、PUT、PATCH、DELETE 方法应被放在同一个业务流程中理解，避免只输出端点清单。",
-                    "当接口返回结构依赖 DTO 或 Entity 时，页面应跳转阅读对应的数据模型页，以确认字段生命周期和兼容性约束。",
-                    "",
-                    "## 性能考虑",
-                    "",
-                    "接口性能主要受鉴权、序列化、数据库访问和外部服务调用影响。若证据中出现批处理、分页或异步任务，"
-                    "应优先检查限流、超时和幂等策略。缺少这些约束时，后续实现需要补充 API 治理说明。",
-                    "",
-                ]
-            )
-        elif page.category == WikiTaxonomyCategory.DATA_MODELS:
-            lines.extend(
-                [
-                    "## 依赖关系分析",
-                    "",
-                    "数据模型页面需要区分核心实体、传输 DTO、配置 Schema 和迁移脚本。"
-                    "同名模型如果跨服务出现，应按业务语义归并，而不是把每个类都作为独立核心实体。",
-                    "字段解释应优先引用 Entity、migration 或 OpenAPI schema 中的来源。",
-                    "",
-                    "## 性能考虑",
-                    "",
-                    "模型性能关注索引、主键、外键、JSON 字段和序列化成本。"
-                    "当页面证据只来自 DTO 而缺少数据库定义时，应把该模型标记为服务边界模型，而不是持久化实体。",
-                    "",
-                ]
-            )
-        else:
-            lines.extend(
-                [
-                    "## 依赖关系分析",
-                    "",
-                    "该主题的依赖关系应从文件路径、符号引用和服务目录共同判断。"
-                    "如果证据集中在单一服务，说明该页面偏向服务内部知识；如果证据分布在多个服务，说明它更接近平台级能力。",
-                    "后续变更时，应优先检查这些证据文件是否发生修改，并据此决定页面是否需要增量重生成。",
-                    "",
-                    "## 性能考虑",
-                    "",
-                    "性能风险主要来自跨服务调用、批处理任务、扫描范围和运行时缓存。"
-                    "当页面涉及生成、索引或验证流程时，应额外关注是否存在全量重跑、重复 IO 或无法恢复的长任务。",
-                    "",
-                ]
-            )
-
-        lines.extend(
-            [
-                "## 故障排查指南",
-                "",
-                "排查该主题时，建议按三步执行：先确认页面引用的文件是否仍存在，再检查相关符号是否改名或迁移，"
-                "最后对照运行命令、测试用例和配置文件确认行为是否发生变化。",
-                "如果生成结果与人工理解不一致，应优先扩展 evidence ranking，而不是只修改模板文案。",
-                "",
-                "## 结论",
-                "",
-                f"`{page.title}` 是当前仓库知识树中的一个可追溯专题页。"
-                "本页已提供源码证据、结构解释和维护检查点，可用于 IDE 插件浏览、人工验收和后续增量生成。",
-            ]
-        )
-
-        return "\n".join(lines)
+            body = self._fallback_topic_markdown(title, evidence)
+        return "\n".join([f"# {title}", "", *body]).strip() + "\n"
 
     def _summarize_evidence_for_fallback(self, binding: Any | None) -> dict[str, Any]:
         summary: dict[str, Any] = {
@@ -1661,6 +1701,8 @@ class RepoWikiService:
                         "path": path,
                         "symbol": symbol,
                         "summary": text,
+                        "line_start": getattr(span, "line_start", 1),
+                        "line_end": getattr(span, "line_end", 1),
                     }
                 )
 
@@ -1671,8 +1713,8 @@ class RepoWikiService:
         cleaned = re.sub(r"\s+", " ", cleaned)
         if not cleaned:
             return ""
-        if len(cleaned) > 180:
-            return cleaned[:177].rstrip() + "..."
+        if len(cleaned) > 360:
+            return cleaned[:357].rstrip() + "..."
         return cleaned
 
     def _page_requires_hard_mermaid(self, page: Any) -> bool:
@@ -2123,7 +2165,7 @@ class RepoWikiService:
             paragraph = (
                 f"\n{page.title} 的阅读重点不是罗列文件，而是把源码证据、模块职责、调用边界和维护风险串联起来。"
                 "读者可以先查看目录确认主题范围，再根据源码引用定位实现位置，最后结合架构图或 schema 摘要判断变更影响。"
-                "如果页面来自 fallback 生成链路，它仍然保留证据绑定结果，但需要在后续优化中用真实 LLM 叙述替换保守说明。"
+                "阅读时请对照文中的源码引用核对实现，不要把未引用的通用说法当成本仓库事实。"
             )
             content += paragraph
             prose = self._count_prose_chars(content)

--- a/tests/test_fallback_onboarding_markdown.py
+++ b/tests/test_fallback_onboarding_markdown.py
@@ -1,0 +1,164 @@
+"""Fallback pages must read as onboarding wiki, not generator meta."""
+
+from __future__ import annotations
+
+from repo_wiki.core.config import RepoWikiConfig
+from repo_wiki.evidence.ranking import EvidenceCandidate, PageEvidenceBinding
+from repo_wiki.orchestration.runtime_store import EvidenceSpanRecord
+from repo_wiki.orchestration.service import RepoWikiService
+from repo_wiki.planner.schema import WikiPagePlan, WikiTaxonomyCategory
+
+GENERATOR_JARGON = (
+    "fallback composer",
+    "page_id",
+    "repo-agent",
+    "evidence ranking",
+    "该页面对应",
+)
+
+README_QUICKSTART = """
+Quickstart
+==========
+
+Install PostgreSQL, then set DATABASE_URL and run docker compose up.
+After the stack is healthy, run the test suite with pytest.
+"""
+
+AUTH_TOKEN_SNIPPET = """
+def get_current_user(authorization: str = Header(...)):
+    token = authorization.removeprefix("Token ")
+    return lookup_user_by_api_token(token)
+"""
+
+
+def _service() -> RepoWikiService:
+    cfg = RepoWikiConfig()
+    cfg.project.root = "."
+    return RepoWikiService(cfg)
+
+
+def _page(*, page_id: str, title: str, category: WikiTaxonomyCategory) -> WikiPagePlan:
+    return WikiPagePlan(
+        page_id=page_id,
+        title=title,
+        category=category,
+        output_path=f"docs/pages/{page_id}.md",
+    )
+
+
+def _binding(
+    *, file_path: str, span_text: str, symbol: str, line_end: int = 20
+) -> PageEvidenceBinding:
+    span = EvidenceSpanRecord(
+        digest="fallback-onboarding",
+        file_path=file_path,
+        line_start=1,
+        line_end=line_end,
+        language="text",
+        symbol=symbol,
+        span_text=span_text,
+    )
+    candidate = EvidenceCandidate(
+        evidence_id=1,
+        span=span,
+        score=1.0,
+        match_signals=["file_proximity"],
+        citation_order=0,
+    )
+    return PageEvidenceBinding(
+        page_id="unused-binding-id",
+        doc_type="overview",
+        candidates=[candidate],
+        bound_count=1,
+    )
+
+
+def _assert_no_generator_jargon(markdown: str) -> None:
+    lowered = markdown.lower()
+    for needle in GENERATOR_JARGON:
+        assert needle.lower() not in lowered, f"fallback jargon leaked: {needle!r}"
+
+
+def _assert_prose_floor(service: RepoWikiService, markdown: str) -> None:
+    assert service._count_prose_chars(markdown) >= 260
+
+
+def test_overview_fallback_uses_readme_quickstart_not_generator_meta() -> None:
+    service = _service()
+    page = _page(
+        page_id="project-overview",
+        title="项目概述",
+        category=WikiTaxonomyCategory.PROJECT_OVERVIEW,
+    )
+    binding = _binding(file_path="README.rst", span_text=README_QUICKSTART, symbol="Quickstart")
+
+    markdown = service._fallback_markdown_for_failed_page(page, binding)
+
+    _assert_no_generator_jargon(markdown)
+    _assert_prose_floor(service, markdown)
+    assert "README.rst" in markdown
+    assert "<cite>README.rst:" in markdown
+    assert "PostgreSQL" in markdown
+    assert "docker" in markdown.lower()
+    assert "DATABASE_URL" in markdown
+
+
+def test_installation_fallback_surfaces_how_to_run_evidence() -> None:
+    service = _service()
+    page = _page(
+        page_id="installation",
+        title="安装指南",
+        category=WikiTaxonomyCategory.PROJECT_OVERVIEW,
+    )
+    binding = _binding(file_path="README.rst", span_text=README_QUICKSTART, symbol="Quickstart")
+
+    markdown = service._fallback_markdown_for_failed_page(page, binding)
+
+    _assert_no_generator_jargon(markdown)
+    _assert_prose_floor(service, markdown)
+    assert "README.rst" in markdown
+    assert "PostgreSQL" in markdown
+    assert "docker" in markdown.lower()
+    assert "DATABASE_URL" in markdown
+    assert "该证据用于限定本文的描述范围" not in markdown
+
+
+def test_security_fallback_avoids_composer_jargon() -> None:
+    service = _service()
+    page = _page(
+        page_id="security-overview",
+        title="安全合规概览",
+        category=WikiTaxonomyCategory.SECURITY_COMPLIANCE,
+    )
+    binding = _binding(
+        file_path="app/core/security.py",
+        span_text=AUTH_TOKEN_SNIPPET,
+        symbol="get_current_user",
+        line_end=12,
+    )
+
+    markdown = service._fallback_markdown_for_failed_page(page, binding)
+
+    _assert_no_generator_jargon(markdown)
+    _assert_prose_floor(service, markdown)
+    assert "app/core/security.py" in markdown
+    assert "Token" in markdown
+    assert "本页聚焦认证授权、审计记录和安全控制点" not in markdown
+
+
+def test_empty_binding_has_no_jargon_and_invents_no_paths() -> None:
+    service = _service()
+    page = _page(
+        page_id="project-overview",
+        title="项目概述",
+        category=WikiTaxonomyCategory.PROJECT_OVERVIEW,
+    )
+
+    markdown = service._fallback_markdown_for_failed_page(page, None)
+
+    _assert_no_generator_jargon(markdown)
+    _assert_prose_floor(service, markdown)
+    assert "README.rst" not in markdown
+    assert "app/core/security.py" not in markdown
+    assert "<cite>" not in markdown
+    assert "无法" in markdown or "不能" in markdown


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

接手仓库的新人会先打开「项目概述 / 安装 / 安全」。LLM compose 失败时，`_fallback_markdown_for_failed_page` 过去会写出生成器元模板（`fallback composer`、`page_id`、`evidence ranking`、IDE 插件验收等），把 README Quickstart 证据埋在套话下面。

本 PR 把 fallback 改写成可读的入门 Wiki：用已绑定证据（路径、符号、片段）作为正文，中文框住英文摘录，并用 `<cite>path:start-end</cite>` 保留可点击引用。没有证据时明确说本页无法从仓库补全，且不编造路径。

## Type of Change
- [x] Bug fix (non-breaking change which fixes a bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (typos, docs, etc.)
- [ ] Refactoring (no functional changes)
- [x] Tests (adding or updating tests)

## Scope / non-goals
- Branched from current `main`. Does **not** merge or edit open PRs #71–#90.
- Does **not** start a generate.
- Does **not** relax HARD/SOFT gates or the 95% citation floor.
- Does **not** change `DEGRADED` → `PASS` for fallback pages.
- Fallback remains enabled; rejected LLM pages still do not count as PASS quality.
- Product code + tests only. No eval docs.

## Testing Performed
- [x] Ran tests locally: `pytest tests/test_fallback_onboarding_markdown.py tests/test_qoder_page_contract_truthfulness.py tests/test_qoder_like_page_floor.py tests/test_quality_guardrails.py`
- [x] Ran linting: `ruff check` / `ruff format --check` on touched files

## Checklist
- [x] My code follows the project's code style
- [x] I have performed self-review
- [x] I have commented complex code areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec34bae2-6b9a-472e-8a20-47fd3c578442?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec34bae2-6b9a-472e-8a20-47fd3c578442&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

